### PR TITLE
Big fix internal search routes

### DIFF
--- a/app/routes/opds.py
+++ b/app/routes/opds.py
@@ -51,7 +51,7 @@ def get_provider(base: str) -> OpenLibraryDataProvider:
     OpenLibraryDataProvider.OL_BASE_URL = OL_BASE_URL
     OpenLibraryDataProvider.USER_AGENT = OL_USER_AGENT
     OpenLibraryDataProvider.REQUEST_TIMEOUT = OL_REQUEST_TIMEOUT
-    OpenLibraryDataProvider.SEARCH_URL = "/search"
+    OpenLibraryDataProvider.SEARCH_URL = f"{base}/search"
     OpenLibraryDataProvider.OPDS_BASE_URL = base
     return OpenLibraryDataProvider()
 
@@ -146,7 +146,7 @@ async def opds_home(request: Request):
                 type=OPDS_MEDIA_TYPE,
                 title=subject["presentable_name"],
                 href=(
-                    f"{base}{search_url}?sort=trending"
+                    f"{search_url}?sort=trending"
                     f"&query=subject_key:{subject['key'].split('/')[-1]}"
                     f' -subject:"content_warning:cover"'
                     f" ebook_access:[borrowable TO *]"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi>=0.111.0
 uvicorn[standard]>=0.29.0
 git+https://github.com/ArchiveLabs/pyopds2.git@7b4242461d0c2cebf83728fda79e60cc63d0fab9
-git+https://github.com/ArchiveLabs/pyopds2_openlibrary.git@e18e79f9a06afeaabe59d7dd8d50b1646db0646c
+git+https://github.com/ArchiveLabs/pyopds2_openlibrary.git@1445b106357604934fbad28215023cbe7a2ff3ed
 httpx>=0.27.0
 requests>=2.32.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -120,10 +120,12 @@ class TestOpdsHome:
         assert self_link["href"] == "https://example.com/opds/"
 
     def test_publication_self_links_use_opds_base(self):
+        from pyopds2_openlibrary import OpenLibraryDataProvider as OLP
         record = _make_record(edition_key="OL99M")
         with patch(SEARCH_PATCH_TARGET, return_value=_make_search_response(records=[record], total=1)):
             with patch("app.routes.opds.OPDS_BASE_URL", "https://myopds.example.com"):
-                data = client.get("/").json()
+                with patch.object(OLP, "OPDS_BASE_URL", "https://myopds.example.com", create=True):
+                    data = client.get("/").json()
         for group in data.get("groups", []):
             for pub in group.get("publications", []):
                 self_link = next(
@@ -204,13 +206,15 @@ class TestOpdsSearch:
         assert "query=hello" in self_link["href"]
 
     def test_publication_self_links_use_opds_base(self):
+        from pyopds2_openlibrary import OpenLibraryDataProvider as OLP
         record = _make_record(edition_key="OL42M")
         with patch(
             SEARCH_PATCH_TARGET,
             return_value=_make_search_response(records=[record], total=1),
         ):
             with patch("app.routes.opds.OPDS_BASE_URL", "https://myopds.example.com"):
-                data = client.get("/search?query=test").json()
+                with patch.object(OLP, "OPDS_BASE_URL", "https://myopds.example.com", create=True):
+                    data = client.get("/search?query=test").json()
         pub_self = next(
             l for l in data["publications"][0]["links"] if l["rel"] == "self"
         )
@@ -252,13 +256,15 @@ class TestOpdsBooks:
         assert "detail" in data
 
     def test_self_link_uses_opds_base(self):
+        from pyopds2_openlibrary import OpenLibraryDataProvider as OLP
         record = _make_record(edition_key="OL55M")
         with patch(
             SEARCH_PATCH_TARGET,
             return_value=_make_search_response(records=[record], total=1),
         ):
             with patch("app.routes.opds.OPDS_BASE_URL", "https://myopds.example.com"):
-                data = client.get("/books/OL55M").json()
+                with patch.object(OLP, "OPDS_BASE_URL", "https://myopds.example.com", create=True):
+                    data = client.get("/books/OL55M").json()
         self_link = next(l for l in data["links"] if l["rel"] == "self")
         assert self_link["href"] == "https://myopds.example.com/books/OL55M"
         assert "openlibrary.org" not in self_link["href"]


### PR DESCRIPTION
Closes #4 
This pull request introduces several improvements to the OPDS API routes and their test coverage. The main changes focus on rewriting publication self links to use the OPDS server's URLs, consolidating shared links, and enhancing error handling for upstream requests. The test suite is expanded to cover these behaviors, including new fixtures, link rewriting, and error scenarios.

**OPDS API improvements:**

* Added `_rewrite_pub_self_links` and `_rewrite_publication_links` functions to ensure all publication self links are rewritten to use the OPDS server's base URL, removing references to Open Library URLs. These are now invoked in all relevant endpoints. [[1]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R66-R100) [[2]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9L144-R182) [[3]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9L181-R217) [[4]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R231)
* Introduced `_common_links` function to consolidate shared catalog links (search, shelf, profile), reducing duplication and improving maintainability. [[1]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R37-R49) [[2]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9L144-R182) [[3]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9L181-R217)

**Error handling enhancements:**

* Updated `_search` to handle both `httpx` and `requests_lib` exceptions, providing more robust upstream error handling and clearer logging.

**Test suite improvements:**

* Refactored tests to use fixtures (`mock_empty_search`, `mock_single_record`) for patching search responses, reducing repetitive code and improving readability.
* Added tests to verify that publication self links are rewritten correctly in all endpoints, and that base URLs are used for self links. [[1]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L195-R298) [[2]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6R198-R218)
* Expanded error handling tests to cover upstream HTTP and connection errors from both `httpx` and `requests_lib`, ensuring proper 502 responses.

**Minor improvements:**

* Cleaned up test helpers and patched imports for consistency. [[1]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6R14-R23) [[2]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L29-R36) [[3]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L49-R51)

These changes collectively improve the reliability, maintainability, and correctness of the OPDS API and its test coverage.