### PR TITLE
Return upstream errors to client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi>=0.111.0
 uvicorn[standard]>=0.29.0
 python-dotenv>=1.0.0
 git+https://github.com/ArchiveLabs/pyopds2.git@7b4242461d0c2cebf83728fda79e60cc63d0fab9
-git+https://github.com/ArchiveLabs/pyopds2_openlibrary.git@9d19ef8a72608029aa54f3d4a88eb5031478fb53
+git+https://github.com/ArchiveLabs/pyopds2_openlibrary.git@b628e020d8f4be84e63379cc6e50ba1e88f657c5
 requests>=2.32.0
 httpx>=0.27.0
 sentry-sdk[fastapi]>=2.0.0


### PR DESCRIPTION
If we don't get any results on the frontpage, we should assume that there is an error on the upstream, and instead return a 502 so it can be correctly handled in the client.