### PR TITLE
fix: update error handling to use httpx and improve caching logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ USER appuser
 
 EXPOSE 8080
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port 8080 --workers ${WEB_CONCURRENCY:-1}"]

--- a/app/routes/opds.py
+++ b/app/routes/opds.py
@@ -6,7 +6,6 @@ import asyncio
 import time
 
 import httpx
-import requests as requests_lib
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
 
@@ -83,17 +82,14 @@ def _search(provider: OpenLibraryDataProvider, **kwargs):
                     kwargs.get("query"), kwargs.get("limit"),
                     kwargs.get("offset", 0), kwargs.get("sort"))
         return provider.search(**kwargs)
-    except (httpx.HTTPStatusError, requests_lib.exceptions.HTTPError) as exc:
-        response = exc.response
-        status_code = response.status_code if response is not None else 502
-        url = getattr(exc, "request", None)
-        url = url.url if url else "?"
-        logger.error("upstream HTTP error status=%s url=%s", status_code, url)
+    except httpx.HTTPStatusError as exc:
+        status_code = exc.response.status_code
+        logger.error("upstream HTTP error status=%s url=%s", status_code, exc.request.url)
         raise UpstreamError(
             f"OpenLibrary returned {status_code}",
             status_code=status_code,
         ) from exc
-    except (httpx.RequestError, requests_lib.exceptions.RequestException) as exc:
+    except httpx.RequestError as exc:
         logger.error("upstream request error: %s", exc)
         raise UpstreamError(f"Could not reach OpenLibrary: {exc}") from exc
 
@@ -106,18 +102,25 @@ async def opds_home(
     logger.info("GET / client=%s", request.client)
     base = _base_url(request)
 
+    # Treat /?mode=everything as equivalent to / for caching purposes.
+    is_default_mode = not request.url.query or request.url.query == "mode=everything"
     cached = _home_cache.get(base)
-    if ENVIRONMENT != "development" and not request.url.query and cached and (time.monotonic() - cached[0]) < HOME_CACHE_TTL:
+    if ENVIRONMENT != "development" and is_default_mode and cached and (time.monotonic() - cached[0]) < HOME_CACHE_TTL:
         logger.info("serving cached homepage for base=%s", base)
         return opds_response(cached[1])
 
     provider = get_provider(base)
     search_url = OpenLibraryDataProvider.SEARCH_URL
 
+    # Mode-aware ebook_access filter for group queries.
+    # open_access uses ebook_access:public so groups populate with Standard Ebooks,
+    # Project Gutenberg, etc. All other modes use the borrowable range.
+    ea = "ebook_access:public" if mode == "open_access" else "ebook_access:[borrowable TO *]"
+
     groups_config = [
         (
             "Trending Books",
-            'trending_score_hourly_sum:[1 TO *] -subject:"content_warning:cover" ebook_access:[borrowable TO *] readinglog_count:[4 TO *]',
+            f'trending_score_hourly_sum:[1 TO *] -subject:"content_warning:cover" {ea} readinglog_count:[4 TO *]',
             "trending",
         ),
         (
@@ -127,22 +130,22 @@ async def opds_home(
         ),
         (
             "Romance",
-            'subject:romance ebook_access:[borrowable TO *] first_publish_year:[1930 TO *] trending_score_hourly_sum:[1 TO *] -subject:"content_warning:cover"',
+            f'subject:romance {ea} first_publish_year:[1930 TO *] trending_score_hourly_sum:[1 TO *] -subject:"content_warning:cover"',
             "trending,trending_score_hourly_sum",
         ),
         (
             "Kids",
-            'ebook_access:[borrowable TO *] trending_score_hourly_sum:[1 TO *] (subject_key:(juvenile_audience OR children\'s_fiction OR juvenile_nonfiction OR juvenile_encyclopedias OR juvenile_riddles OR juvenile_poetry OR juvenile_wit_and_humor OR juvenile_limericks OR juvenile_dictionaries OR juvenile_non-fiction) OR subject:("Juvenile literature" OR "Juvenile fiction" OR "pour la jeunesse" OR "pour enfants"))',
+            f'{ea} trending_score_hourly_sum:[1 TO *] (subject_key:(juvenile_audience OR children\'s_fiction OR juvenile_nonfiction OR juvenile_encyclopedias OR juvenile_riddles OR juvenile_poetry OR juvenile_wit_and_humor OR juvenile_limericks OR juvenile_dictionaries OR juvenile_non-fiction) OR subject:("Juvenile literature" OR "Juvenile fiction" OR "pour la jeunesse" OR "pour enfants"))',
             "random.hourly",
         ),
         (
             "Thrillers",
-            'subject:thrillers ebook_access:[borrowable TO *] trending_score_hourly_sum:[1 TO *] -subject:"content_warning:cover"',
+            f'subject:thrillers {ea} trending_score_hourly_sum:[1 TO *] -subject:"content_warning:cover"',
             "trending,trending_score_hourly_sum",
         ),
         (
             "Textbooks",
-            'subject_key:textbooks publish_year:[1990 TO *] ebook_access:[borrowable TO *]',
+            f'subject_key:textbooks publish_year:[1990 TO *] {ea}',
             "trending",
         ),
     ]
@@ -173,6 +176,7 @@ async def opds_home(
             href=f"{search_url}?{urlencode({
                 'sort': 'trending',
                 'title': subject['presentable_name'],
+                'language': 'eng',
                 'query': (
                     f'subject_key:{subject["key"].split("/")[-1]}'
                     f' -subject:"content_warning:cover"'
@@ -200,7 +204,7 @@ async def opds_home(
         ],
     )
     data = catalog.model_dump()
-    if ENVIRONMENT != "development" and not request.url.query:
+    if ENVIRONMENT != "development" and is_default_mode:
         _home_cache[base] = (time.monotonic(), data)
     return opds_response(data)
 
@@ -214,12 +218,20 @@ async def opds_search(
     sort: Optional[str] = Query(default=None),
     mode: str = Query(default="everything", description="Search mode, e.g. 'ebooks' or 'everything'"),
     title: Optional[str] = Query(default=None, description="Display title for the results page"),
+    language: str = Query(default="eng", description="MARC language code to prefer (e.g. 'eng', 'fre')"),
 ):
-    logger.info("GET /search query=%r limit=%s page=%s sort=%s mode=%s", query, limit, page, sort, mode)
+    logger.info("GET /search query=%r limit=%s page=%s sort=%s mode=%s language=%s", query, limit, page, sort, mode, language)
     base = _base_url(request)
     provider = get_provider(base)
 
     self_href = f"{base}/search?{request.url.query}" if request.url.query else f"{base}/search"
+
+    def _fetch_facet_counts_safe(q: str) -> dict:
+        try:
+            return OpenLibraryDataProvider.fetch_facet_counts(q)
+        except Exception as exc:
+            logger.warning("facet count fetch failed, omitting counts: %s", exc)
+            return {}
 
     search_response, availability_counts = await asyncio.gather(
         asyncio.to_thread(
@@ -230,10 +242,10 @@ async def opds_search(
             offset=(page - 1) * limit,
             sort=sort,
             facets={"mode": mode},
-            language="eng",
+            language=language,
             title=title,
         ),
-        asyncio.to_thread(OpenLibraryDataProvider.fetch_facet_counts, query),
+        asyncio.to_thread(_fetch_facet_counts_safe, query),
     )
 
     safe_total = _safe_total(getattr(search_response, "total", None))
@@ -257,6 +269,7 @@ async def opds_search(
             query=query,
             sort=sort,
             mode=mode,
+            language=language,
             total=safe_total,
             availability_counts=availability_counts,
         ),

--- a/app/routes/opds.py
+++ b/app/routes/opds.py
@@ -154,7 +154,7 @@ async def opds_home(
         try:
             resp = await asyncio.to_thread(
                 _search, provider, query=q, sort=sort, limit=25,
-                language="eng", facets={"mode": mode}, title=title,
+                language="en", facets={"mode": mode}, title=title,
             )
             return Catalog.create(metadata=Metadata(title=title), response=resp)
         except UpstreamError as exc:
@@ -176,7 +176,7 @@ async def opds_home(
             href=f"{search_url}?{urlencode({
                 'sort': 'trending',
                 'title': subject['presentable_name'],
-                'language': 'eng',
+                'language': 'en',
                 'query': (
                     f'subject_key:{subject["key"].split("/")[-1]}'
                     f' -subject:"content_warning:cover"'
@@ -218,7 +218,7 @@ async def opds_search(
     sort: Optional[str] = Query(default=None),
     mode: str = Query(default="everything", description="Search mode, e.g. 'ebooks' or 'everything'"),
     title: Optional[str] = Query(default=None, description="Display title for the results page"),
-    language: str = Query(default="eng", description="MARC language code to prefer (e.g. 'eng', 'fre')"),
+    language: str = Query(default="en", description="Language code to prefer (e.g. 'en', 'fr')"),
 ):
     logger.info("GET /search query=%r limit=%s page=%s sort=%s mode=%s language=%s", query, limit, page, sort, mode, language)
     base = _base_url(request)
@@ -282,7 +282,7 @@ async def opds_books(request: Request, edition_olid: str):
     logger.info("GET /books/%s", edition_olid)
     base = _base_url(request)
     provider = get_provider(base)
-    resp = await asyncio.to_thread(_search, provider, query=f"edition_key:{edition_olid}", language="eng")
+    resp = await asyncio.to_thread(_search, provider, query=f"edition_key:{edition_olid}", language="en")
     if not resp.records:
         logger.warning("edition not found: %s", edition_olid)
         raise EditionNotFound(edition_olid)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     env_file:
       - path: .env
         required: false
+    environment:
+      - WEB_CONCURRENCY=${WEB_CONCURRENCY:-1}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,4 +17,4 @@ USER appuser
 
 EXPOSE 8080
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["sh", "-c", "exec uvicorn app.main:app --host 0.0.0.0 --port 8080 --workers ${WEB_CONCURRENCY:-1}"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ fastapi>=0.111.0
 uvicorn[standard]>=0.29.0
 python-dotenv>=1.0.0
 git+https://github.com/ArchiveLabs/pyopds2.git@7b4242461d0c2cebf83728fda79e60cc63d0fab9
-git+https://github.com/ArchiveLabs/pyopds2_openlibrary.git@201b8153a98984219dd6dda708aff569f0e0153a
+git+https://github.com/ArchiveLabs/pyopds2_openlibrary.git@6939a31c03717b996fb003aea92a6b8c462a1fe5
 httpx>=0.27.0
 sentry-sdk[fastapi]>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ uvicorn[standard]>=0.29.0
 python-dotenv>=1.0.0
 git+https://github.com/ArchiveLabs/pyopds2.git@7b4242461d0c2cebf83728fda79e60cc63d0fab9
 git+https://github.com/ArchiveLabs/pyopds2_openlibrary.git@b628e020d8f4be84e63379cc6e50ba1e88f657c5
-requests>=2.32.0
 httpx>=0.27.0
 sentry-sdk[fastapi]>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ fastapi>=0.111.0
 uvicorn[standard]>=0.29.0
 python-dotenv>=1.0.0
 git+https://github.com/ArchiveLabs/pyopds2.git@7b4242461d0c2cebf83728fda79e60cc63d0fab9
-git+https://github.com/ArchiveLabs/pyopds2_openlibrary.git@b628e020d8f4be84e63379cc6e50ba1e88f657c5
+git+https://github.com/ArchiveLabs/pyopds2_openlibrary.git@201b8153a98984219dd6dda708aff569f0e0153a
 httpx>=0.27.0
 sentry-sdk[fastapi]>=2.0.0

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -21,6 +21,11 @@ OL_REQUEST_TIMEOUT=30.0
 SENTRY_DSN=https://8d8cab445edc9b4e452ba06d0be46dcb@sentry.archive.org/73
 SENTRY_TRACES_SAMPLE_RATE=0.1
 SENTRY_PROFILE_SESSION_SAMPLE_RATE=0.1
+
+# Number of uvicorn worker processes. Each worker is an independent process
+# with its own in-memory cache — no shared state, no thread-safety concerns.
+# Recommended: 2-4 for most deployments. Default: 1 (safe for low-memory envs).
+WEB_CONCURRENCY=3
 EOF
 
 chmod 600 "$ENV_FILE"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,10 +8,10 @@ Network calls to openlibrary.org are mocked so tests run offline.
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
+import httpx
 import pytest
-import requests as requests_lib
 from fastapi.testclient import TestClient
 
 from app.main import app
@@ -175,14 +175,16 @@ class TestOpdsHome:
         """If one shelf fails upstream, the rest still load."""
         call_count = 0
         record = _make_record()
+        _req = httpx.Request("GET", "https://openlibrary.org/search.json")
 
         def flaky_search(**kwargs):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                raise requests_lib.exceptions.HTTPError(
+                raise httpx.HTTPStatusError(
                     "500 Server Error",
-                    response=MagicMock(status_code=500),
+                    request=_req,
+                    response=httpx.Response(500, request=_req),
                 )
             return _make_search_response(records=[record], total=1)
 
@@ -319,7 +321,6 @@ class TestOpdsBooks:
         assert self_link["href"].startswith("https://myopds.example.com/")
         assert "OL55M" in self_link["href"]
         assert "openlibrary.org" not in self_link["href"]
-        assert "openlibrary.org" not in self_link["href"]
 
 
 # ---------------------------------------------------------------------------
@@ -327,19 +328,20 @@ class TestOpdsBooks:
 # ---------------------------------------------------------------------------
 
 class TestUpstreamErrors:
-    def test_requests_http_error_returns_502(self):
-        mock_response = MagicMock(status_code=500)
-        mock_request = MagicMock()
-        mock_request.url = "https://openlibrary.org/search.json"
-        exc = requests_lib.exceptions.HTTPError(
-            "500 Server Error", response=mock_response, request=mock_request
+    def test_httpx_http_status_error_returns_502(self):
+        _req = httpx.Request("GET", "https://openlibrary.org/search.json")
+        exc = httpx.HTTPStatusError(
+            "500 Server Error",
+            request=_req,
+            response=httpx.Response(500, request=_req),
         )
         with patch(SEARCH_PATCH_TARGET, side_effect=exc):
             resp = client.get("/search?query=test")
         assert resp.status_code == 502
 
-    def test_requests_connection_error_returns_502(self):
-        exc = requests_lib.exceptions.ConnectionError("Connection refused")
+    def test_httpx_request_error_returns_502(self):
+        _req = httpx.Request("GET", "https://openlibrary.org/search.json")
+        exc = httpx.ConnectError("Connection refused", request=_req)
         with patch(SEARCH_PATCH_TARGET, side_effect=exc):
             resp = client.get("/search?query=test")
         assert resp.status_code == 502
@@ -372,37 +374,33 @@ class TestSearchModes:
         )
 
 
+
 # ---------------------------------------------------------------------------
 # Facets
 # ---------------------------------------------------------------------------
 
-def _fake_facets(base_url="", query="test", sort=None, mode="everything", total=0, availability_counts=None):
-    """Return realistic facet data matching what build_facets would produce."""
-    sort_links = [
-        {"title": "Relevance", "href": f"{base_url}/search?query={query}",
-         "rel": "self http://opds-spec.org/sort/relevance" if sort is None else "http://opds-spec.org/sort/relevance",
-         "type": "application/opds+json", "properties": {"numberOfItems": total}},
-        {"title": "Most Recent", "href": f"{base_url}/search?query={query}&sort=new",
-         "rel": "self http://opds-spec.org/sort/new" if sort == "new" else "http://opds-spec.org/sort/new",
-         "type": "application/opds+json", "properties": {"numberOfItems": total}},
-        {"title": "Trending", "href": f"{base_url}/search?query={query}&sort=trending",
-         "rel": "self http://opds-spec.org/sort/trending" if sort == "trending" else "http://opds-spec.org/sort/trending",
-         "type": "application/opds+json", "properties": {"numberOfItems": total}},
-    ]
+def _fake_facets(base_url="", query="test", sort=None, mode="everything", language=None, total=0, availability_counts=None):
+    """Return realistic facet data matching what build_facets now produces (Availability only).
+
+    Only the active mode link carries rel="self"; non-active links have no rel key,
+    matching the real _build_availability_links output.
+    """
     counts = availability_counts or _FAKE_AVAILABILITY_COUNTS
+
+    def _avail_link(mode_val, title, href):
+        link = {"title": title, "href": href, "type": "application/opds+json",
+                "properties": {"numberOfItems": counts.get(mode_val, 0)}}
+        if mode_val == mode:
+            link["rel"] = "self"
+        return link
+
     avail_links = [
-        {"title": "All", "href": f"{base_url}/search?query={query}&mode=everything",
-         "rel": "self" if mode == "everything" else "http://opds-spec.org/facet",
-         "type": "application/opds+json", "properties": {"numberOfItems": counts.get("everything", 0)}},
-        {"title": "Available to Borrow", "href": f"{base_url}/search?query={query}&mode=ebooks",
-         "rel": "self" if mode == "ebooks" else "http://opds-spec.org/facet",
-         "type": "application/opds+json", "properties": {"numberOfItems": counts.get("ebooks", 0)}},
-        {"title": "Open Access", "href": f"{base_url}/search?query={query}&mode=open_access",
-         "rel": "self" if mode == "open_access" else "http://opds-spec.org/facet",
-         "type": "application/opds+json", "properties": {"numberOfItems": counts.get("open_access", 0)}},
+        _avail_link("everything",  "Everything",            f"{base_url}/search?query={query}"),
+        _avail_link("ebooks",      "Available to Borrow",   f"{base_url}/search?query={query}&mode=ebooks"),
+        _avail_link("open_access", "Open Access",           f"{base_url}/search?query={query}&mode=open_access"),
+        _avail_link("buyable",     "Available to Purchase", f"{base_url}/search?query={query}&mode=buyable"),
     ]
     return [
-        {"metadata": {"title": "Sort"}, "links": sort_links},
         {"metadata": {"title": "Availability"}, "links": avail_links},
     ]
 
@@ -419,38 +417,31 @@ class TestFacets:
     def test_search_response_includes_facets(self, mock_empty_search):
         data = client.get("/search?query=test").json()
         assert "facets" in data
-        assert len(data["facets"]) == 2
-
-    def test_sort_facet_has_metadata_title(self, mock_empty_search):
-        data = client.get("/search?query=test").json()
-        sort_facet = data["facets"][0]
-        assert sort_facet["metadata"]["title"] == "Sort"
+        assert len(data["facets"]) == 1
 
     def test_availability_facet_has_metadata_title(self, mock_empty_search):
         data = client.get("/search?query=test").json()
-        avail_facet = data["facets"][1]
+        avail_facet = data["facets"][0]
         assert avail_facet["metadata"]["title"] == "Availability"
 
-    def test_active_sort_facet_has_self_rel(self, mock_empty_search):
-        data = client.get("/search?query=test&sort=new").json()
-        sort_links = data["facets"][0]["links"]
-        new_link = next(l for l in sort_links if l["title"] == "Most Recent")
-        rel = new_link["rel"]
-        assert "self" in rel
-        assert "http://opds-spec.org/sort/new" in rel
+    def test_no_sort_facet_in_response(self, mock_empty_search):
+        data = client.get("/search?query=test").json()
+        titles = [f["metadata"]["title"] for f in data["facets"]]
+        assert "Sort" not in titles
 
     def test_active_availability_facet_has_self_rel(self, mock_empty_search):
         data = client.get("/search?query=test&mode=ebooks").json()
-        avail_links = data["facets"][1]["links"]
+        avail_links = data["facets"][0]["links"]
         ebooks_link = next(l for l in avail_links if l["title"] == "Available to Borrow")
         assert ebooks_link["rel"] == "self"
 
-    def test_sort_facet_links_have_numberOfItems(self, mock_single_record):
+    def test_availability_labels_match_canonical(self, mock_empty_search):
         data = client.get("/search?query=test").json()
-        sort_links = data["facets"][0]["links"]
-        for link in sort_links:
-            assert "properties" in link
-            assert "numberOfItems" in link["properties"]
+        titles = {l["title"] for l in data["facets"][0]["links"]}
+        assert "Everything" in titles
+        assert "Available to Borrow" in titles
+        assert "Open Access" in titles
+        assert "Available to Purchase" in titles
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -237,7 +237,7 @@ class TestOpdsSearch:
         client.get("/search?query=test&page=2&limit=10")
         mock_empty_search.assert_called_once_with(
             query="test", limit=10, offset=10, sort=None, facets={"mode": "everything"},
-            language="eng", title=None,
+            language="en", title=None,
         )
 
     def test_invalid_limit_rejected(self):
@@ -356,21 +356,21 @@ class TestSearchModes:
         client.get("/search?query=test&mode=ebooks")
         mock_empty_search.assert_called_once_with(
             query="test", limit=25, offset=0, sort=None, facets={"mode": "ebooks"},
-            language="eng", title=None,
+            language="en", title=None,
         )
 
     def test_open_access_mode_forwarded(self, mock_empty_search):
         client.get("/search?query=test&mode=open_access")
         mock_empty_search.assert_called_once_with(
             query="test", limit=25, offset=0, sort=None, facets={"mode": "open_access"},
-            language="eng", title=None,
+            language="en", title=None,
         )
 
     def test_buyable_mode_forwarded(self, mock_empty_search):
         client.get("/search?query=test&mode=buyable")
         mock_empty_search.assert_called_once_with(
             query="test", limit=25, offset=0, sort=None, facets={"mode": "buyable"},
-            language="eng", title=None,
+            language="en", title=None,
         )
 
 


### PR DESCRIPTION
Closes https://github.com/ArchiveLabs/pyopds2_openlibrary/issues/54 https://github.com/ArchiveLabs/pyopds2_openlibrary/issues/55 https://github.com/ArchiveLabs/pyopds2_openlibrary/issues/53 https://github.com/ArchiveLabs/pyopds2_openlibrary/issues/46 

This pull request refactors error handling to use only the `httpx` library (removing all `requests` dependencies), improves language handling in search endpoints, updates group queries for more flexible ebook access filtering, and adds support for configuring the number of Uvicorn worker processes via environment variables. It also updates tests to match the new error handling and facet structure.

**Error handling and dependency cleanup:**
- Refactored all upstream HTTP error handling to use only `httpx` exceptions, removing all usage of the `requests` library from both the application code and tests. This simplifies dependencies and ensures consistent error handling. [[1]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9L9) [[2]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9L86-R92) [[3]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L11-L14) [[4]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6R178-R187) [[5]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L322-R344)

**Search and language improvements:**

> - Added a `language` query parameter (defaulting to `"eng"`) to the `/search` endpoint, allowing clients to specify preferred MARC language codes. This parameter is now logged, forwarded to the provider, and included in the response. [[1]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R221-R235) [[2]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9L233-R248) [[3]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R272)

now it move to just `en` 

- Updated group queries on the homepage to use a dynamic ebook access filter (`ea`) based on the current mode, improving the accuracy of book groupings for different access types. [[1]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R105-R123) [[2]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9L130-R148)

**Caching and homepage behavior:**
- Adjusted homepage caching logic to treat `/?mode=everything` as equivalent to `/`, ensuring cache hits regardless of query parameter order and improving cache efficiency. [[1]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R105-R123) [[2]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9L203-R207)

**Deployment and concurrency:**
- Added support for configuring the number of Uvicorn worker processes via a `WEB_CONCURRENCY` environment variable, with Docker and configuration script updates to set a sensible default and allow overrides. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R11-R12) [[2]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL20-R20) [[3]](diffhunk://#diff-8460fd1802e463cea1c367ba6866f9e3f97baa7763cf754bf8061b2921af6249R24-R28)

**Testing and facets:**
- Updated tests to match the new facet structure, removing sort facets and ensuring only the availability facet is present, with canonical labels and correct `rel="self"` usage for active links. [[1]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6R377-L405) [[2]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L422-R444)