### PR TITLE
feat: add access filter to search and author routes, update Sentry integration

### DIFF
--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -20,7 +20,10 @@ OL_USER_AGENT: str = os.environ.get(
 )
 OL_REQUEST_TIMEOUT: float = float(os.environ.get("OL_REQUEST_TIMEOUT", "30.0"))
 
-SENTRY_DSN: str | None = os.environ.get("SENTRY_DSN")
+SENTRY_DSN: str | None = os.environ.get(
+    "SENTRY_DSN",
+    "https://8d8cab445edc9b4e452ba06d0be46dcb@sentry.archive.org/73",
+)
 SENTRY_TRACES_SAMPLE_RATE: float = float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.1"))
 SENTRY_PROFILE_SESSION_SAMPLE_RATE: float = float(os.environ.get("SENTRY_PROFILE_SESSION_SAMPLE_RATE", "0.1"))
 

--- a/app/routes/opds.py
+++ b/app/routes/opds.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 import asyncio
+import inspect
 import time
 
 import httpx
@@ -81,7 +82,7 @@ def _search(provider: OpenLibraryDataProvider, **kwargs):
         logger.info("search query=%r limit=%s offset=%s sort=%s",
                     kwargs.get("query"), kwargs.get("limit"),
                     kwargs.get("offset", 0), kwargs.get("sort"))
-        return provider.search(**kwargs)
+        return _call_provider_compat(provider.search, **kwargs)
     except httpx.HTTPStatusError as exc:
         status_code = exc.response.status_code
         logger.error("upstream HTTP error status=%s url=%s", status_code, exc.request.url)
@@ -94,6 +95,27 @@ def _search(provider: OpenLibraryDataProvider, **kwargs):
         raise UpstreamError(f"Could not reach OpenLibrary: {exc}") from exc
 
 
+def _call_provider_compat(func, **kwargs):
+    """Call provider methods while tolerating older signatures.
+
+    This keeps newer route parameters (like ``access``) from crashing when
+    an older ``pyopds2_openlibrary`` version is imported at runtime.
+    """
+    signature = inspect.signature(func)
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
+        return func(**kwargs)
+
+    supported = {k: v for k, v in kwargs.items() if k in signature.parameters}
+    skipped = sorted(set(kwargs) - set(supported))
+    if skipped:
+        logger.warning(
+            "provider call %s does not support parameters %s; ignoring them",
+            getattr(func, "__qualname__", getattr(func, "__name__", str(func))),
+            skipped,
+        )
+    return func(**supported)
+
+
 @router.get("/", summary="OPDS 2.0 homepage")
 async def opds_home(
     request: Request,
@@ -101,12 +123,13 @@ async def opds_home(
     language: Optional[str] = Query(default=None, description="BCP 47 language filter (e.g. 'en'). Omit for all languages."),
     page: int = Query(default=1, ge=1, description="Group page (each page loads a batch of carousels)"),
     media_type: Optional[str] = Query(default=None, description="Media type filter: ebook, audiobook. Omit for all."),
+    access: Optional[str] = Query(default=None, description="Access filter: general (default), print_disabled."),
 ):
-    logger.info("GET / client=%s language=%s page=%s media_type=%s", request.client, language, page, media_type)
+    logger.info("GET / client=%s language=%s page=%s media_type=%s access=%s", request.client, language, page, media_type, access)
     base = _base_url(request)
 
     # Only cache the fully-default first page.
-    is_default = mode == "everything" and language is None and page == 1 and media_type is None
+    is_default = mode == "everything" and language is None and page == 1 and media_type is None and access is None
     cached = _home_cache.get(base)
     if ENVIRONMENT != "development" and is_default and cached and (time.monotonic() - cached[0]) < HOME_CACHE_TTL:
         logger.info("serving cached homepage for base=%s", base)
@@ -115,8 +138,14 @@ async def opds_home(
     get_provider(base)
 
     data = await asyncio.to_thread(
+        _call_provider_compat,
         OpenLibraryDataProvider.build_home_feed,
-        base=base, mode=mode, language=language, page=page, media_type=media_type,
+        base=base,
+        mode=mode,
+        language=language,
+        page=page,
+        media_type=media_type,
+        access=access,
     )
 
     if ENVIRONMENT != "development" and is_default:
@@ -135,8 +164,9 @@ async def opds_search(
     title: Optional[str] = Query(default=None, description="Display title for the results page"),
     language: Optional[str] = Query(default=None, description="BCP 47 language filter (e.g. 'en'). Omit for all languages."),
     media_type: Optional[str] = Query(default=None, description="Media type filter: ebook, audiobook. Omit for all."),
+    access: Optional[str] = Query(default=None, description="Access filter: general (default), print_disabled."),
 ):
-    logger.info("GET /search query=%r limit=%s page=%s sort=%s mode=%s language=%s media_type=%s", query, limit, page, sort, mode, language, media_type)
+    logger.info("GET /search query=%r limit=%s page=%s sort=%s mode=%s language=%s media_type=%s access=%s", query, limit, page, sort, mode, language, media_type, access)
     base = _base_url(request)
     provider = get_provider(base)
 
@@ -162,6 +192,7 @@ async def opds_search(
             title=title,
             require_cover=False,
             media_type=media_type,
+            access=access,
         ),
         asyncio.to_thread(_fetch_facet_counts_safe, query),
     )
@@ -182,7 +213,8 @@ async def opds_search(
             Link(rel="self", href=self_href, type=OPDS_MEDIA_TYPE),
             *_common_links(base),
         ],
-        facets=OpenLibraryDataProvider.build_facets(
+        facets=_call_provider_compat(
+            OpenLibraryDataProvider.build_facets,
             base_url=base,
             query=query,
             sort=sort,
@@ -192,6 +224,7 @@ async def opds_search(
             total=safe_total,
             availability_counts=availability_counts,
             media_type=media_type,
+            access=access,
         ),
     )
     return opds_response(catalog.model_dump())
@@ -219,8 +252,9 @@ async def opds_authors(
     mode: str = Query(default="everything"),
     language: Optional[str] = Query(default=None, description="BCP 47 language filter (e.g. 'en'). Omit for all languages."),
     media_type: Optional[str] = Query(default=None, description="Media type filter: ebook, audiobook. Omit for all."),
+    access: Optional[str] = Query(default=None, description="Access filter: general (default), print_disabled."),
 ):
-    logger.info("GET /authors/%s page=%s limit=%s mode=%s language=%s media_type=%s", olid, page, limit, mode, language, media_type)
+    logger.info("GET /authors/%s page=%s limit=%s mode=%s language=%s media_type=%s access=%s", olid, page, limit, mode, language, media_type, access)
     base = _base_url(request)
     provider = get_provider(base)
 
@@ -235,6 +269,7 @@ async def opds_authors(
             language=language,
             media_type=media_type,
             require_cover=False,
+            access=access,
         ),
     )
 
@@ -253,6 +288,8 @@ async def opds_authors(
             params["language"] = language
         if media_type:
             params["media_type"] = media_type
+        if access and access != "general":
+            params["access"] = access
         return f"{base}/authors/{olid}?{urlencode(params)}" if params else f"{base}/authors/{olid}"
 
     catalog_links: list[Link] = [
@@ -276,7 +313,8 @@ async def opds_authors(
         response=search_response,
         paginate=False,
         links=catalog_links,
-        facets=OpenLibraryDataProvider.build_author_facets(
+        facets=_call_provider_compat(
+            OpenLibraryDataProvider.build_author_facets,
             base_url=base,
             olid=olid,
             mode=mode,
@@ -284,6 +322,7 @@ async def opds_authors(
             media_type=media_type,
             page=page,
             limit=limit,
+            access=access,
         ),
     )
     return opds_response(catalog.model_dump())

--- a/app/sentry.py
+++ b/app/sentry.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import logging
+
 import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
 
 from app.config import (
     ENVIRONMENT,
@@ -11,7 +14,7 @@ from app.config import (
 
 
 def init_sentry() -> bool:
-    if not SENTRY_DSN:
+    if not SENTRY_DSN or ENVIRONMENT == "test":
         return False
     sentry_sdk.init(
         dsn=SENTRY_DSN,
@@ -21,5 +24,11 @@ def init_sentry() -> bool:
         traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
         profile_session_sample_rate=SENTRY_PROFILE_SESSION_SAMPLE_RATE,
         profile_lifecycle="trace",
+        integrations=[
+            LoggingIntegration(
+                level=logging.INFO,        # forward INFO+ to Sentry structured logs
+                event_level=logging.ERROR, # create Sentry events for ERROR+
+            ),
+        ],
     )
     return True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 testpaths = tests
+env =
+    ENVIRONMENT=test

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi>=0.111.0
 uvicorn[standard]>=0.29.0
 python-dotenv>=1.0.0
 git+https://github.com/ArchiveLabs/pyopds2.git@7b4242461d0c2cebf83728fda79e60cc63d0fab9
-git+https://github.com/ArchiveLabs/pyopds2_openlibrary.git@130eee0d9d3fa1a38166e9d5b7ddb4e74f14c6fd
+git+https://github.com/ArchiveLabs/pyopds2_openlibrary.git@14bfaf7cfae22957879a09996d17bbf36fbada12
 httpx>=0.27.0
 markdown-it-py>=3.0.0
 sentry-sdk[fastapi]>=2.0.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -297,7 +297,7 @@ class TestOpdsSearch:
         client.get("/search?query=test&page=2&limit=10")
         mock_empty_search.assert_called_once_with(
             query="test", limit=10, offset=10, sort=None, facets={"mode": "everything"},
-            language=None, title=None, require_cover=False, media_type=None,
+            language=None, title=None, require_cover=False, media_type=None, access=None,
         )
 
     def test_invalid_limit_rejected(self):
@@ -416,28 +416,28 @@ class TestSearchModes:
         client.get("/search?query=test&mode=ebooks")
         mock_empty_search.assert_called_once_with(
             query="test", limit=25, offset=0, sort=None, facets={"mode": "ebooks"},
-            language=None, title=None, require_cover=False, media_type=None,
+            language=None, title=None, require_cover=False, media_type=None, access=None,
         )
 
     def test_open_access_mode_forwarded(self, mock_empty_search):
         client.get("/search?query=test&mode=open_access")
         mock_empty_search.assert_called_once_with(
             query="test", limit=25, offset=0, sort=None, facets={"mode": "open_access"},
-            language=None, title=None, require_cover=False, media_type=None,
+            language=None, title=None, require_cover=False, media_type=None, access=None,
         )
 
-    def test_print_disabled_mode_forwarded(self, mock_empty_search):
-        client.get("/search?query=test&mode=print_disabled")
+    def test_access_print_disabled_forwarded(self, mock_empty_search):
+        client.get("/search?query=test&access=print_disabled")
         mock_empty_search.assert_called_once_with(
-            query="test", limit=25, offset=0, sort=None, facets={"mode": "print_disabled"},
-            language=None, title=None, require_cover=False, media_type=None,
+            query="test", limit=25, offset=0, sort=None, facets={"mode": "everything"},
+            language=None, title=None, require_cover=False, media_type=None, access="print_disabled",
         )
 
     def test_buyable_mode_forwarded(self, mock_empty_search):
         client.get("/search?query=test&mode=buyable")
         mock_empty_search.assert_called_once_with(
             query="test", limit=25, offset=0, sort=None, facets={"mode": "buyable"},
-            language=None, title=None, require_cover=False, media_type=None,
+            language=None, title=None, require_cover=False, media_type=None, access=None,
         )
 
 
@@ -446,30 +446,42 @@ class TestSearchModes:
 # Facets
 # ---------------------------------------------------------------------------
 
-def _fake_facets(base_url="", query="test", sort=None, mode="everything", language=None, title=None, total=0, availability_counts=None, media_type=None):
-    """Return realistic facet data matching what build_facets now produces (Availability only).
+def _fake_facets(base_url="", query="test", sort=None, mode="everything", language=None, title=None, total=0, availability_counts=None, media_type=None, access=None):
+    """Return realistic facet data matching what build_facets now produces.
 
-    Only the active mode link carries rel="self"; non-active links have no rel key,
-    matching the real _build_availability_links output.
+    Only the active mode/access link carries rel="self"; non-active links have no rel key,
+    matching the real _build_availability_links / _build_access_links output.
     """
     counts = availability_counts or _FAKE_AVAILABILITY_COUNTS
 
-    def _avail_link(mode_val, title, href):
-        link = {"title": title, "href": href, "type": "application/opds+json",
+    def _avail_link(mode_val, lbl, href):
+        link = {"title": lbl, "href": href, "type": "application/opds+json",
                 "properties": {"numberOfItems": counts.get(mode_val, 0)}}
         if mode_val == mode:
             link["rel"] = "self"
         return link
 
+    active_access = access or "general"
+
+    def _access_link(ac_val, lbl, href):
+        link = {"title": lbl, "href": href, "type": "application/opds+json"}
+        if ac_val == active_access:
+            link["rel"] = "self"
+        return link
+
     avail_links = [
-        _avail_link("everything",     "Everything",            f"{base_url}/search?query={query}"),
-        _avail_link("ebooks",         "Available to Borrow",   f"{base_url}/search?query={query}&mode=ebooks"),
-        _avail_link("print_disabled", "Print Disabled",        f"{base_url}/search?query={query}&mode=print_disabled"),
-        _avail_link("open_access",    "Open Access",           f"{base_url}/search?query={query}&mode=open_access"),
-        _avail_link("buyable",        "Available for Purchase", f"{base_url}/search?query={query}&mode=buyable"),
+        _avail_link("everything",  "Everything",            f"{base_url}/search?query={query}"),
+        _avail_link("ebooks",      "Available to Borrow",   f"{base_url}/search?query={query}&mode=ebooks"),
+        _avail_link("open_access", "Open Access",           f"{base_url}/search?query={query}&mode=open_access"),
+        _avail_link("buyable",     "Available for Purchase", f"{base_url}/search?query={query}&mode=buyable"),
+    ]
+    access_links = [
+        _access_link("general",        "General",       f"{base_url}/search?query={query}"),
+        _access_link("print_disabled", "Print Disabled", f"{base_url}/search?query={query}&access=print_disabled"),
     ]
     return [
         {"metadata": {"title": "Availability"}, "links": avail_links},
+        {"metadata": {"title": "Access"}, "links": access_links},
     ]
 
 
@@ -485,12 +497,12 @@ class TestFacets:
     def test_search_response_includes_facets(self, mock_empty_search):
         data = client.get("/search?query=test").json()
         assert "facets" in data
-        assert len(data["facets"]) == 1
+        assert len(data["facets"]) == 2
 
     def test_availability_facet_has_metadata_title(self, mock_empty_search):
         data = client.get("/search?query=test").json()
-        avail_facet = data["facets"][0]
-        assert avail_facet["metadata"]["title"] == "Availability"
+        facet_titles = {f["metadata"]["title"] for f in data["facets"]}
+        assert "Availability" in facet_titles
 
     def test_no_sort_facet_in_response(self, mock_empty_search):
         data = client.get("/search?query=test").json()
@@ -499,18 +511,39 @@ class TestFacets:
 
     def test_active_availability_facet_has_self_rel(self, mock_empty_search):
         data = client.get("/search?query=test&mode=ebooks").json()
-        avail_links = data["facets"][0]["links"]
-        ebooks_link = next(l for l in avail_links if l["title"] == "Available to Borrow")
+        avail = next(f for f in data["facets"] if f["metadata"]["title"] == "Availability")
+        ebooks_link = next(l for l in avail["links"] if l["title"] == "Available to Borrow")
         assert ebooks_link["rel"] == "self"
 
     def test_availability_labels_match_canonical(self, mock_empty_search):
         data = client.get("/search?query=test").json()
-        titles = {l["title"] for l in data["facets"][0]["links"]}
+        avail = next(f for f in data["facets"] if f["metadata"]["title"] == "Availability")
+        titles = {l["title"] for l in avail["links"]}
         assert "Everything" in titles
         assert "Available to Borrow" in titles
-        assert "Print Disabled" in titles
         assert "Open Access" in titles
         assert "Available for Purchase" in titles
+        assert "Print Disabled" not in titles
+
+    def test_access_facet_present(self, mock_empty_search):
+        data = client.get("/search?query=test").json()
+        access_facet = next((f for f in data["facets"] if f["metadata"]["title"] == "Access"), None)
+        assert access_facet is not None
+        titles = {l["title"] for l in access_facet["links"]}
+        assert "General" in titles
+        assert "Print Disabled" in titles
+
+    def test_active_access_facet_has_self_rel(self, mock_empty_search):
+        data = client.get("/search?query=test&access=print_disabled").json()
+        access_facet = next(f for f in data["facets"] if f["metadata"]["title"] == "Access")
+        pd_link = next(l for l in access_facet["links"] if l["title"] == "Print Disabled")
+        assert pd_link["rel"] == "self"
+
+    def test_general_access_is_default_active(self, mock_empty_search):
+        data = client.get("/search?query=test").json()
+        access_facet = next(f for f in data["facets"] if f["metadata"]["title"] == "Access")
+        general_link = next(l for l in access_facet["links"] if l["title"] == "General")
+        assert general_link.get("rel") == "self"
 
 
 # ---------------------------------------------------------------------------
@@ -522,14 +555,14 @@ class TestMediaTypeFacet:
         client.get("/search?query=test&media_type=audiobook")
         mock_empty_search.assert_called_once_with(
             query="test", limit=25, offset=0, sort=None, facets={"mode": "everything"},
-            language=None, title=None, require_cover=False, media_type="audiobook",
+            language=None, title=None, require_cover=False, media_type="audiobook", access=None,
         )
 
     def test_ebook_media_type_forwarded(self, mock_empty_search):
         client.get("/search?query=test&media_type=ebook")
         mock_empty_search.assert_called_once_with(
             query="test", limit=25, offset=0, sort=None, facets={"mode": "everything"},
-            language=None, title=None, require_cover=False, media_type="ebook",
+            language=None, title=None, require_cover=False, media_type="ebook", access=None,
         )
 
     def test_media_type_in_build_facets_call(self, mock_empty_search):
@@ -801,6 +834,7 @@ class TestOpdsAuthors:
         assert "Availability" in facet_titles
         assert "Language" in facet_titles
         assert "Media Type" in facet_titles
+        assert "Access" in facet_titles
 
     def test_author_availability_facet_no_buyable(self):
         record = _make_record()
@@ -990,3 +1024,258 @@ class TestAuthorNotFound:
         exc = AuthorNotFound("OL123A")
         assert str(exc) == "Author not found: OL123A"
         assert exc.author_olid == "OL123A"
+
+
+# ---------------------------------------------------------------------------
+# Issue #75: Smart description fallback
+# ---------------------------------------------------------------------------
+
+class TestSmartDescriptionFallback:
+    def _make_record_with_desc(self, edition_desc=None, work_desc=None, lang=None):
+        from pyopds2_openlibrary import OpenLibraryDataRecord
+        doc: dict = {
+            "key": "/works/OL1W",
+            "title": "Test Book",
+            "editions": {
+                "numFound": 1, "start": 0, "numFoundExact": True,
+                "docs": [{"key": "/books/OL1M", "title": "Test Book"}],
+            },
+        }
+        if work_desc:
+            doc["description"] = work_desc
+        if lang:
+            doc["editions"]["docs"][0]["language"] = lang
+        if edition_desc:
+            doc["editions"]["docs"][0]["description"] = edition_desc
+        return OpenLibraryDataRecord.model_validate(doc)
+
+    def test_edition_description_used_when_present(self):
+        record = self._make_record_with_desc(edition_desc="Edition desc.", work_desc="Work desc.", lang=["eng"])
+        assert record.metadata().description == "Edition desc."
+
+    def test_work_description_fallback_for_english(self):
+        record = self._make_record_with_desc(work_desc="Work desc.", lang=["eng"])
+        assert record.metadata().description == "Work desc."
+
+    def test_no_fallback_for_non_english(self):
+        record = self._make_record_with_desc(work_desc="Work desc.", lang=["fre"])
+        assert record.metadata().description is None
+
+    def test_no_fallback_when_no_work_desc(self):
+        record = self._make_record_with_desc(lang=["eng"])
+        assert record.metadata().description is None
+
+    def test_no_fallback_when_no_language(self):
+        record = self._make_record_with_desc(work_desc="Work desc.")
+        assert record.metadata().description is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #76: Group descriptions
+# ---------------------------------------------------------------------------
+
+class TestGroupDescriptions:
+    def test_standard_ebooks_group_has_description(self, mock_single_record):
+        # Standard Ebooks is the last group — scan all pages until we find it.
+        num_pages = 3
+        se_group = None
+        for p in range(1, num_pages + 1):
+            data = client.get(f"/?page={p}").json()
+            se_group = next(
+                (g for g in data.get("groups", []) if g.get("metadata", {}).get("title") == "Standard Ebooks"),
+                None,
+            )
+            if se_group:
+                break
+        assert se_group is not None, "Standard Ebooks group not found on any homepage page"
+        assert se_group["metadata"].get("description") is not None
+        assert "Standard Ebooks" in se_group["metadata"]["description"]
+
+    def test_group_descriptions_dict_has_standard_ebooks(self):
+        from pyopds2_openlibrary import _GROUP_DESCRIPTIONS
+        assert "Standard Ebooks" in _GROUP_DESCRIPTIONS
+        assert len(_GROUP_DESCRIPTIONS["Standard Ebooks"]) > 10
+
+    def test_group_descriptions_dict_has_classic_books(self):
+        from pyopds2_openlibrary import _GROUP_DESCRIPTIONS
+        assert "Classic Books" in _GROUP_DESCRIPTIONS
+        assert len(_GROUP_DESCRIPTIONS["Classic Books"]) > 10
+
+    def test_group_descriptions_dict_has_kids(self):
+        from pyopds2_openlibrary import _GROUP_DESCRIPTIONS
+        assert "Kids" in _GROUP_DESCRIPTIONS
+        assert len(_GROUP_DESCRIPTIONS["Kids"]) > 10
+
+
+# ---------------------------------------------------------------------------
+# Issue #73: Access facet post-filter
+# ---------------------------------------------------------------------------
+
+class TestAccessFilter:
+    def test_printdisabled_records_excluded_by_default(self):
+        from pyopds2_openlibrary import OpenLibraryDataProvider, OpenLibraryDataRecord
+
+        pd_record = OpenLibraryDataRecord.model_validate({
+            "key": "/works/OL2W", "title": "Print Disabled Book",
+            "ebook_access": "printdisabled",
+            "editions": {"numFound": 1, "start": 0, "numFoundExact": True,
+                         "docs": [{"key": "/books/OL2M", "title": "PD Book",
+                                   "ebook_access": "printdisabled",
+                                   "providers": [{"provider_name": "ia", "url": "https://archive.org/x"}],
+                                   "ia": ["someident"], "cover_i": 1}]},
+        })
+        borrowable_record = OpenLibraryDataRecord.model_validate({
+            "key": "/works/OL3W", "title": "Borrowable Book",
+            "ebook_access": "borrowable",
+            "editions": {"numFound": 1, "start": 0, "numFoundExact": True,
+                         "docs": [{"key": "/books/OL3M", "title": "Borrow Book",
+                                   "ebook_access": "borrowable",
+                                   "providers": [{"provider_name": "ia", "url": "https://archive.org/y"}],
+                                   "ia": ["otherid"], "cover_i": 2}]},
+        })
+
+        with patch("pyopds2_openlibrary._get") as mock_get:
+            mock_get.return_value.json.return_value = {
+                "docs": [pd_record.model_dump(), borrowable_record.model_dump()],
+                "numFound": 2,
+            }
+            resp = OpenLibraryDataProvider.search(
+                query="test", require_cover=False, access=None,
+            )
+        titles = [r.title for r in resp.records]
+        assert "Borrowable Book" in titles
+        assert "Print Disabled Book" not in titles
+
+    def test_printdisabled_records_shown_with_access_param(self):
+        from pyopds2_openlibrary import OpenLibraryDataProvider, OpenLibraryDataRecord
+
+        pd_record = OpenLibraryDataRecord.model_validate({
+            "key": "/works/OL2W", "title": "Print Disabled Book",
+            "ebook_access": "printdisabled",
+            "editions": {"numFound": 1, "start": 0, "numFoundExact": True,
+                         "docs": [{"key": "/books/OL2M", "title": "PD Book",
+                                   "ebook_access": "printdisabled",
+                                   "providers": [{"provider_name": "ia", "url": "https://archive.org/x"}],
+                                   "ia": ["someident"], "cover_i": 1}]},
+        })
+
+        with patch("pyopds2_openlibrary._get") as mock_get:
+            mock_get.return_value.json.return_value = {
+                "docs": [pd_record.model_dump()],
+                "numFound": 1,
+            }
+            resp = OpenLibraryDataProvider.search(
+                query="test", require_cover=False, access="print_disabled",
+            )
+        titles = [r.title for r in resp.records]
+        assert "Print Disabled Book" in titles
+
+    def test_access_param_forwarded_to_search_from_route(self, mock_empty_search):
+        client.get("/search?query=test&access=print_disabled")
+        _, kwargs = mock_empty_search.call_args
+        assert kwargs.get("access") == "print_disabled"
+
+    def test_author_access_param_forwarded(self):
+        record = _make_record()
+        with patch(FETCH_AUTHOR_BIO_PATCH_TARGET, return_value=("Author", None)), \
+             patch(SEARCH_PATCH_TARGET, return_value=_make_search_response(records=[record], total=1)) as mock_s:
+            client.get("/authors/OL1234A?access=print_disabled")
+        _, kwargs = mock_s.call_args
+        assert kwargs.get("access") == "print_disabled"
+
+    def test_access_facet_links_preserve_current_access(self):
+        record = _make_record()
+        with patch(FETCH_AUTHOR_BIO_PATCH_TARGET, return_value=("Author", None)), \
+             patch(SEARCH_PATCH_TARGET, return_value=_make_search_response(records=[record], total=1)):
+            data = client.get("/authors/OL1234A?access=print_disabled&mode=ebooks").json()
+        access_facet = next(f for f in data["facets"] if f["metadata"]["title"] == "Access")
+        pd_link = next(l for l in access_facet["links"] if l["title"] == "Print Disabled")
+        assert "access=print_disabled" in pd_link["href"]
+
+    def _make_pd_and_borrowable(self):
+        from pyopds2_openlibrary import OpenLibraryDataRecord
+        pd = OpenLibraryDataRecord.model_validate({
+            "key": "/works/OL2W", "title": "Print Disabled Book",
+            "ebook_access": "printdisabled",
+            "editions": {"numFound": 1, "start": 0, "numFoundExact": True,
+                         "docs": [{"key": "/books/OL2M", "title": "PD Book",
+                                   "ebook_access": "printdisabled",
+                                   "providers": [{"provider_name": "ia", "url": "https://archive.org/x"}],
+                                   "ia": ["someident"], "cover_i": 1}]},
+        })
+        borrowable = OpenLibraryDataRecord.model_validate({
+            "key": "/works/OL3W", "title": "Borrowable Book",
+            "ebook_access": "borrowable",
+            "editions": {"numFound": 1, "start": 0, "numFoundExact": True,
+                         "docs": [{"key": "/books/OL3M", "title": "Borrow Book",
+                                   "ebook_access": "borrowable",
+                                   "providers": [{"provider_name": "ia", "url": "https://archive.org/y"}],
+                                   "ia": ["otherid"], "cover_i": 2}]},
+        })
+        return pd, borrowable
+
+    def test_printdisabled_excluded_with_ebooks_mode(self):
+        from pyopds2_openlibrary import OpenLibraryDataProvider
+        pd, borrowable = self._make_pd_and_borrowable()
+        with patch("pyopds2_openlibrary._get") as mock_get:
+            mock_get.return_value.json.return_value = {
+                "docs": [pd.model_dump(), borrowable.model_dump()],
+                "numFound": 2,
+            }
+            resp = OpenLibraryDataProvider.search(
+                query="test", require_cover=False, access=None,
+                facets={"mode": "ebooks"},
+            )
+        titles = [r.title for r in resp.records]
+        assert "Borrowable Book" in titles
+        assert "Print Disabled Book" not in titles
+
+    def test_printdisabled_excluded_with_language_filter(self):
+        from pyopds2_openlibrary import OpenLibraryDataProvider
+        pd, borrowable = self._make_pd_and_borrowable()
+        with patch("pyopds2_openlibrary._get") as mock_get, \
+             patch("pyopds2_openlibrary.iso_639_1_to_marc", return_value="eng"):
+            mock_get.return_value.json.return_value = {
+                "docs": [pd.model_dump(), borrowable.model_dump()],
+                "numFound": 2,
+            }
+            resp = OpenLibraryDataProvider.search(
+                query="test", require_cover=False, access=None,
+                language="en",
+            )
+        titles = [r.title for r in resp.records]
+        assert "Borrowable Book" in titles
+        assert "Print Disabled Book" not in titles
+
+    def test_printdisabled_excluded_with_media_type_ebook(self):
+        from pyopds2_openlibrary import OpenLibraryDataProvider
+        pd, borrowable = self._make_pd_and_borrowable()
+        with patch("pyopds2_openlibrary._get") as mock_get:
+            mock_get.return_value.json.return_value = {
+                "docs": [pd.model_dump(), borrowable.model_dump()],
+                "numFound": 2,
+            }
+            resp = OpenLibraryDataProvider.search(
+                query="test", require_cover=False, access=None,
+                media_type="ebook",
+            )
+        titles = [r.title for r in resp.records]
+        assert "Borrowable Book" in titles
+        assert "Print Disabled Book" not in titles
+
+    def test_printdisabled_excluded_with_all_facets_combined(self):
+        from pyopds2_openlibrary import OpenLibraryDataProvider
+        pd, borrowable = self._make_pd_and_borrowable()
+        with patch("pyopds2_openlibrary._get") as mock_get, \
+             patch("pyopds2_openlibrary.iso_639_1_to_marc", return_value="eng"):
+            mock_get.return_value.json.return_value = {
+                "docs": [pd.model_dump(), borrowable.model_dump()],
+                "numFound": 2,
+            }
+            resp = OpenLibraryDataProvider.search(
+                query="test", require_cover=False, access=None,
+                facets={"mode": "ebooks"}, language="en", media_type="ebook",
+            )
+        titles = [r.title for r in resp.records]
+        assert "Borrowable Book" in titles
+        assert "Print Disabled Book" not in titles

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -15,6 +15,7 @@ class TestInitSentry:
 
     def test_returns_true_and_calls_sdk_init(self):
         with patch("app.sentry.SENTRY_DSN", "https://fake@sentry.example.com/1"), \
+             patch("app.sentry.ENVIRONMENT", "production"), \
              patch("app.sentry.sentry_sdk") as mock_sdk:
             from app.sentry import init_sentry
             assert init_sentry() is True


### PR DESCRIPTION
Closes https://github.com/ArchiveLabs/pyopds2_openlibrary/issues/73 https://github.com/ArchiveLabs/pyopds2_openlibrary/issues/75 https://github.com/ArchiveLabs/pyopds2_openlibrary/issues/76
This pull request introduces support for a new "Access" facet to the OPDS API, allowing users to filter results by access type (e.g., "general" or "print_disabled"). It also makes the API more robust to backwards-incompatible provider changes, improves Sentry logging integration, and ensures tests run in a consistent environment.

**New Access Facet and Filtering:**

* Added an `access` query parameter to OPDS endpoints (`/`, `/search`, `/authors/{olid}`) and updated all relevant calls to forward this parameter to provider methods. This enables filtering results by access type, such as "general" or "print_disabled". [[1]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R98-R132) [[2]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R141-R148) [[3]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R167-R169) [[4]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R255-R257) [[5]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R272) [[6]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R291-R292)
* Introduced the Access facet alongside the existing Availability facet in search responses, with correct handling of active states and self-rels. The "Print Disabled" option is now moved from Availability to Access. [[1]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L449-R484) [[2]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L488-R505) [[3]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L502-R546)

**Provider Compatibility Improvements:**

* Added `_call_provider_compat`, a compatibility wrapper that gracefully handles provider methods with older signatures, avoiding crashes when new parameters are added. This is used throughout the codebase for provider calls. [[1]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9L84-R85) [[2]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R98-R132) [[3]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R141-R148) [[4]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9L185-R217) [[5]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9L279-R325)

**Sentry Logging and Configuration:**

* Enhanced Sentry integration to forward INFO+ logs as breadcrumbs and create events for ERROR+ logs, and disabled Sentry in test environments. [[1]](diffhunk://#diff-68726e02b6aa52a9f266cc934185e3f16cb1abaac54502f66d2d69cd947c2659R3-R6) [[2]](diffhunk://#diff-68726e02b6aa52a9f266cc934185e3f16cb1abaac54502f66d2d69cd947c2659L14-R17) [[3]](diffhunk://#diff-68726e02b6aa52a9f266cc934185e3f16cb1abaac54502f66d2d69cd947c2659R27-R32)
* Set a default Sentry DSN (with override via environment variable) and ensured the test environment disables Sentry. [[1]](diffhunk://#diff-39bf3703bf37d9b0f14c926653e79a3a38e8698f16f2829181bc1de6deb2fa70L23-R26) [[2]](diffhunk://#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1R3-R4)

**Testing Updates:**

* Updated and expanded tests to cover the new Access facet, ensure correct parameter forwarding, and verify facet structure and active state logic. [[1]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L300-R300) [[2]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L419-R440) [[3]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L449-R484) [[4]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L488-R505) [[5]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L502-R546) [[6]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L525-R565)

These changes improve the flexibility, robustness, and observability of the OPDS API while maintaining backward compatibility with older provider versions.