### PR TITLE
feat(cache): implement validation for cache entries to prevent blank responses

### DIFF
--- a/app/cache.py
+++ b/app/cache.py
@@ -37,6 +37,10 @@ LANG_OPTIONS_KEY = "opds:lang_options"
 
 _COMPRESSION_THRESHOLD = 10240  # 10 KB
 
+# Backoff window after a memcached op fails. Prevents per-request reconnect storms
+# when memcached is down. New connection attempts gated by monotonic clock.
+_MEMCACHE_RECONNECT_BACKOFF_SECONDS = 5.0
+
 
 # ---------------------------------------------------------------------------
 # Pure helpers (module-level — no state)
@@ -71,6 +75,7 @@ class CacheBackend(Protocol):
         key: str,
         ttl: int,
         fetch: Callable[[], Coroutine[Any, Any, dict]],
+        is_valid: Callable[[dict], bool] | None = None,
     ) -> dict: ...
 
     async def cached_swr(
@@ -79,6 +84,7 @@ class CacheBackend(Protocol):
         fresh_ttl: int,
         stale_ttl: int,
         fetch: Callable[[], Coroutine[Any, Any, dict]],
+        is_valid: Callable[[dict], bool] | None = None,
     ) -> dict: ...
 
 
@@ -100,6 +106,7 @@ class NullCacheBackend:
         key: str,
         ttl: int,
         fetch: Callable[[], Coroutine[Any, Any, dict]],
+        is_valid: Callable[[dict], bool] | None = None,
     ) -> dict:
         return await fetch()
 
@@ -109,6 +116,7 @@ class NullCacheBackend:
         fresh_ttl: int,
         stale_ttl: int,
         fetch: Callable[[], Coroutine[Any, Any, dict]],
+        is_valid: Callable[[dict], bool] | None = None,
     ) -> dict:
         return await fetch()
 
@@ -127,7 +135,7 @@ class MemcachedBackend:
 
     def __init__(self) -> None:
         self._client: PooledClient | None = None
-        self._client_failed: bool = False
+        self._reconnect_after: float = 0.0
         self._locks: dict[str, asyncio.Lock] = {}
         self._refreshing: set[str] = set()
 
@@ -138,6 +146,8 @@ class MemcachedBackend:
     def _get_client(self) -> PooledClient | None:
         if self._client is not None:
             return self._client
+        if time.monotonic() < self._reconnect_after:
+            return None
         logger.info("memcached connecting to %s:%s", MEMCACHE_HOST, MEMCACHE_PORT)
         try:
             self._client = PooledClient(
@@ -149,13 +159,26 @@ class MemcachedBackend:
             )
             return self._client
         except Exception as exc:
-            if not self._client_failed:
-                logger.warning(
-                    "Memcached unavailable (%s:%s): %s — running without cache",
-                    MEMCACHE_HOST, MEMCACHE_PORT, exc,
-                )
-                self._client_failed = True
+            self._invalidate_client(exc)
             return None
+
+    def _invalidate_client(self, exc: BaseException) -> None:
+        """Drop the cached client and arm reconnect backoff after an op failure.
+
+        ``PooledClient(ignore_exc=True)`` does not catch raw socket errors like
+        ``ConnectionRefusedError`` raised by ``_connect``. When memcached is
+        unreachable, every request retries the same broken pool. Resetting the
+        client forces a rebuild after the backoff window — calls in between
+        skip memcached and run uncached.
+        """
+        was_active = self._client is not None
+        self._client = None
+        self._reconnect_after = time.monotonic() + _MEMCACHE_RECONNECT_BACKOFF_SECONDS
+        if was_active:
+            logger.warning(
+                "Memcached op failed (%s:%s): %s — disabling cache for %.1fs",
+                MEMCACHE_HOST, MEMCACHE_PORT, exc, _MEMCACHE_RECONNECT_BACKOFF_SECONDS,
+            )
 
     def _serialize(self, value: dict) -> bytes:
         raw = json.dumps(value, separators=(",", ":")).encode()
@@ -180,7 +203,8 @@ class MemcachedBackend:
             return True  # no Memcached → act as if we own the lock
         try:
             return bool(client.add(f"{key}:lock", b"1", expire=expire))
-        except Exception:
+        except Exception as exc:
+            self._invalidate_client(exc)
             return True  # unexpected failure → fall through, accept possible double-fetch
 
     def _release_distributed_lock(self, key: str) -> None:
@@ -189,8 +213,8 @@ class MemcachedBackend:
             return
         try:
             client.delete(f"{key}:lock")
-        except Exception:
-            pass  # TTL will clean it up
+        except Exception as exc:
+            self._invalidate_client(exc)  # TTL will clean up the lock entry
 
     # ------------------------------------------------------------------
     # Public interface
@@ -204,6 +228,7 @@ class MemcachedBackend:
             raw = client.get(key)
         except Exception as exc:
             logger.warning("cache get error key=%s: %s", key, exc)
+            self._invalidate_client(exc)
             return None
         if raw is None:
             logger.info("cache MISS key=%s", key)
@@ -223,22 +248,54 @@ class MemcachedBackend:
             client.set(key, self._serialize(value), expire=_jitter(ttl))
         except Exception as exc:
             logger.warning("cache set error key=%s: %s", key, exc)
+            self._invalidate_client(exc)
+
+    def _delete(self, key: str) -> None:
+        """Best-effort delete used to evict invalid cache entries."""
+        client = self._get_client()
+        if client is None:
+            return
+        try:
+            client.delete(key)
+        except Exception as exc:
+            logger.warning("cache delete error key=%s: %s", key, exc)
+            self._invalidate_client(exc)
 
     async def cached(
         self,
         key: str,
         ttl: int,
         fetch: Callable[[], Coroutine[Any, Any, dict]],
+        is_valid: Callable[[dict], bool] | None = None,
     ) -> dict:
+        """Cache-or-fetch with optional value validation.
+
+        When ``is_valid`` is supplied it gates both cache reads and writes:
+        a HIT that fails validation is treated as a MISS (and discarded so
+        future requests don't keep returning the poisoned entry), and a
+        fetched value that fails validation is returned to the caller but
+        never written to memcached. Prevents blank/error responses (e.g.
+        ``groups=[]`` from a transient upstream outage) from being pinned
+        for the full TTL.
+        """
+
+        def _valid(v: dict) -> bool:
+            return is_valid is None or is_valid(v)
+
         try:
             result = self.get(key)
-            if result is not None:
+            if result is not None and _valid(result):
                 return result
+            if result is not None:
+                logger.info("cache invalid entry, discarding key=%s", key)
+                self._delete(key)
 
             async with self._locks.setdefault(key, asyncio.Lock()):
                 result = self.get(key)
-                if result is not None:
+                if result is not None and _valid(result):
                     return result
+                if result is not None:
+                    self._delete(key)
 
                 got_distributed_lock = self._acquire_distributed_lock(key)
                 if not got_distributed_lock:
@@ -247,13 +304,16 @@ class MemcachedBackend:
                     for _ in range(15):
                         await asyncio.sleep(0.2)
                         result = self.get(key)
-                        if result is not None:
+                        if result is not None and _valid(result):
                             return result
                     # Lock holder took >3s or crashed — fall through and fetch.
 
                 try:
                     result = await fetch()
-                    self.set(key, result, ttl)
+                    if _valid(result):
+                        self.set(key, result, ttl)
+                    else:
+                        logger.info("cache skip write (invalid result) key=%s", key)
                     return result
                 finally:
                     if got_distributed_lock:
@@ -275,13 +335,17 @@ class MemcachedBackend:
         fresh_ttl: int,
         stale_ttl: int,
         fetch: Callable[[], Coroutine[Any, Any, dict]],
+        is_valid: Callable[[dict], bool] | None = None,
     ) -> None:
         try:
             if not self._acquire_distributed_lock(key, expire=max(fresh_ttl, 30)):
                 return
             try:
                 fresh = await fetch()
-                self._set_swr(key, fresh, fresh_ttl, stale_ttl)
+                if is_valid is None or is_valid(fresh):
+                    self._set_swr(key, fresh, fresh_ttl, stale_ttl)
+                else:
+                    logger.info("cache swr skip write (invalid refresh) key=%s", key)
             finally:
                 self._release_distributed_lock(key)
         except Exception as exc:
@@ -295,38 +359,56 @@ class MemcachedBackend:
         fresh_ttl: int,
         stale_ttl: int,
         fetch: Callable[[], Coroutine[Any, Any, dict]],
+        is_valid: Callable[[dict], bool] | None = None,
     ) -> dict:
         """Stale-while-revalidate. Hot/stale hits return immediately; stale hits
         spawn a background refresh. Misses block-fetch with stampede protection.
+
+        When ``is_valid`` is supplied, cache entries failing validation are
+        discarded on read and never written, so blank responses cannot poison
+        the cache for the full TTL.
         """
+
+        def _valid(v: dict) -> bool:
+            return is_valid is None or is_valid(v)
+
         try:
             wrapped = self.get(key)
             if isinstance(wrapped, dict) and "v" in wrapped:
-                if time.time() < wrapped.get("exp", 0):
+                if _valid(wrapped["v"]):
+                    if time.time() < wrapped.get("exp", 0):
+                        return wrapped["v"]
+                    if key not in self._refreshing:
+                        self._refreshing.add(key)
+                        asyncio.create_task(
+                            self._refresh_in_background(key, fresh_ttl, stale_ttl, fetch, is_valid)
+                        )
                     return wrapped["v"]
-                if key not in self._refreshing:
-                    self._refreshing.add(key)
-                    asyncio.create_task(
-                        self._refresh_in_background(key, fresh_ttl, stale_ttl, fetch)
-                    )
-                return wrapped["v"]
+                # Cached value is invalid (e.g. previously-poisoned blank entry) — evict and refetch.
+                logger.info("cache swr invalid entry, discarding key=%s", key)
+                self._delete(key)
 
             async with self._locks.setdefault(key, asyncio.Lock()):
                 wrapped = self.get(key)
-                if isinstance(wrapped, dict) and "v" in wrapped:
+                if isinstance(wrapped, dict) and "v" in wrapped and _valid(wrapped["v"]):
                     return wrapped["v"]
+                if isinstance(wrapped, dict) and "v" in wrapped:
+                    self._delete(key)
 
                 got_lock = self._acquire_distributed_lock(key)
                 if not got_lock:
                     for _ in range(15):
                         await asyncio.sleep(0.2)
                         wrapped = self.get(key)
-                        if isinstance(wrapped, dict) and "v" in wrapped:
+                        if isinstance(wrapped, dict) and "v" in wrapped and _valid(wrapped["v"]):
                             return wrapped["v"]
 
                 try:
                     result = await fetch()
-                    self._set_swr(key, result, fresh_ttl, stale_ttl)
+                    if _valid(result):
+                        self._set_swr(key, result, fresh_ttl, stale_ttl)
+                    else:
+                        logger.info("cache swr skip write (invalid result) key=%s", key)
                     return result
                 finally:
                     if got_lock:

--- a/app/routes/opds.py
+++ b/app/routes/opds.py
@@ -211,20 +211,32 @@ async def opds_home(
         )
         return group_catalog.model_dump()
 
+    # Reject empty payloads — a homepage with no groups means every upstream
+    # group fetch failed (e.g. OL 403/500) and caching it would pin a blank
+    # response for the full TTL. A trending overlay without publications is
+    # equally useless. Validators run on both reads and writes.
+    def _home_is_valid(d: dict) -> bool:
+        return bool(d.get("groups"))
+
+    def _trending_is_valid(d: dict) -> bool:
+        return bool(d.get("publications"))
+
     # Full page served via stale-while-revalidate for default mode (hot path);
     # other variants stay on plain TTL since they are cold and rarely hit twice.
     if is_default:
         data = await cache.cached_swr(
-            home_key, ttl, TTL_HOME_DEFAULT_STALE_SECONDS, _fetch_full
+            home_key, ttl, TTL_HOME_DEFAULT_STALE_SECONDS, _fetch_full,
+            is_valid=_home_is_valid,
         )
     else:
-        data = await cache.cached(home_key, ttl, _fetch_full)
+        data = await cache.cached(home_key, ttl, _fetch_full, is_valid=_home_is_valid)
 
     # Trending group overlaid via SWR so the 60s refresh never blocks a user.
     groups = data.get("groups", [])
     if any(g.get("metadata", {}).get("title") == "Trending Books" for g in groups):
         fresh_trending = await cache.cached_swr(
-            trending_key, TTL_TRENDING_SECONDS, TTL_TRENDING_STALE_SECONDS, _fetch_trending
+            trending_key, TTL_TRENDING_SECONDS, TTL_TRENDING_STALE_SECONDS, _fetch_trending,
+            is_valid=_trending_is_valid,
         )
         if fresh_trending:
             data = {**data, "groups": [

--- a/app/sentry.py
+++ b/app/sentry.py
@@ -12,9 +12,13 @@ from app.config import (
     SENTRY_TRACES_SAMPLE_RATE,
 )
 
+# Environment values that disable Sentry. Both spellings are accepted so a stray
+# ENVIRONMENT=testing does not pollute Sentry with mock-injected test errors.
+_TEST_ENVIRONMENTS = frozenset({"test", "testing"})
+
 
 def init_sentry() -> bool:
-    if not SENTRY_DSN or ENVIRONMENT == "test":
+    if not SENTRY_DSN or ENVIRONMENT in _TEST_ENVIRONMENTS:
         return False
     sentry_sdk.init(
         dsn=SENTRY_DSN,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi>=0.111.0
 uvicorn[standard]>=0.29.0
 python-dotenv>=1.0.0
 git+https://github.com/ArchiveLabs/pyopds2.git@7b4242461d0c2cebf83728fda79e60cc63d0fab9
-git+https://github.com/ArchiveLabs/pyopds2_openlibrary.git@94447252a571be604d8682c0c0f0774a6e0d0376
+git+https://github.com/ArchiveLabs/pyopds2_openlibrary.git@2913dd24f621ddf477c15f041df27b244c466d0a
 httpx>=0.27.0
 markdown-it-py>=3.0.0
 sentry-sdk[fastapi]>=2.0.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -588,11 +588,11 @@ class RecordingCacheBackend(NullCacheBackend):
     def __init__(self):
         self.cached_calls: list[tuple] = []  # (key, ttl)
 
-    async def cached(self, key: str, ttl: int, fetch):
+    async def cached(self, key: str, ttl: int, fetch, is_valid=None):
         self.cached_calls.append((key, ttl))
         return await fetch()
 
-    async def cached_swr(self, key: str, fresh_ttl: int, stale_ttl: int, fetch):
+    async def cached_swr(self, key: str, fresh_ttl: int, stale_ttl: int, fetch, is_valid=None):
         self.cached_calls.append((key, fresh_ttl))
         return await fetch()
 
@@ -601,10 +601,10 @@ class HitCacheBackend(NullCacheBackend):
     def __init__(self, data: dict):
         self._data = data
 
-    async def cached(self, key: str, ttl: int, fetch):
+    async def cached(self, key: str, ttl: int, fetch, is_valid=None):
         return self._data
 
-    async def cached_swr(self, key: str, fresh_ttl: int, stale_ttl: int, fetch):
+    async def cached_swr(self, key: str, fresh_ttl: int, stale_ttl: int, fetch, is_valid=None):
         return self._data
 
 


### PR DESCRIPTION
This pull request introduces significant improvements to the caching layer, focusing on resilience and correctness, especially when interacting with Memcached and handling potentially invalid cache entries. It adds validation hooks to prevent caching of blank or error responses, implements robust backoff logic for Memcached failures, and ensures that test environments do not pollute Sentry error reporting. Test doubles are also updated to support the new cache API.

**Caching robustness and validation:**

* Added an `is_valid` callback to both `cached` and `cached_swr` methods in `app/cache.py`, allowing callers to validate cache entries on both read and write. Invalid entries are discarded and not written to cache, preventing blank/error responses from being cached for the full TTL. (`app/cache.py` [[1]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afR78) [[2]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afR87) [[3]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afR109) [[4]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afR119) [[5]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afR251-R298) [[6]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afL250-R316) [[7]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afR338-R348) [[8]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afR362-R411); `app/routes/opds.py` [[9]](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R214-R239)
* Updated the OPDS homepage and trending endpoints to use these validators, ensuring that empty group lists or publication lists are not cached. (`app/routes/opds.py` [app/routes/opds.pyR214-R239](diffhunk://#diff-a7978a20fe2ec6d58a378cc7204f33d367376261a4ff6bb4671a1b42769a8ec9R214-R239))

**Resilience to Memcached failures:**

* Implemented a reconnect backoff window after Memcached operation failures. When Memcached is down, the backend now waits before retrying connections, preventing per-request reconnect storms and reducing error logs. (`app/cache.py` [[1]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afR40-R43) [[2]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afL130-R138) [[3]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afR149-R150) [[4]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afL152-L158) [[5]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afL183-R207) [[6]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afL192-R217) [[7]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afR231) [[8]](diffhunk://#diff-4b4dee26e358993f921248adb6606b5734158899fd3783edc42b2039bae3d1afR251-R298)

**Testing and testability:**

* Updated cache test doubles to accept the new `is_valid` parameter, ensuring compatibility with the revised cache API. (`tests/test_app.py` [[1]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L591-R595) [[2]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6L604-R607)

**Error reporting and environment handling:**

* Changed Sentry initialization to recognize both `test` and `testing` environment values, ensuring that test runs do not pollute Sentry with errors. (`app/sentry.py` [app/sentry.pyR15-R21](diffhunk://#diff-68726e02b6aa52a9f266cc934185e3f16cb1abaac54502f66d2d69cd947c2659R15-R21))