### PR TITLE
test(e2e): home feed integration tests (in-process TestClient)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 testpaths = tests
 env =
     ENVIRONMENT=test
+markers =
+    e2e: end-to-end tests requiring a live OL Docker instance (skipped by default)

--- a/tests/e2e/test_home_feed_e2e.py
+++ b/tests/e2e/test_home_feed_e2e.py
@@ -1,13 +1,13 @@
 """
-End-to-end tests for the OPDS home feed.
+End-to-end tests for the OPDS home feed (in-process).
 
-These tests require a live Open Library instance (with the /search/carousels.json
-endpoint from PR #12987) running at OL_BASE_URL (default: http://localhost:8080).
+These tests use FastAPI's TestClient backed by a real OL Docker instance and
+validate home feed structure, content, and filtering parameters.
+
+Automatically skipped when OL is not reachable at OL_BASE_URL.
 
 Run with:
     OL_BASE_URL=http://localhost:8080 pytest tests/e2e/ -m e2e -v
-
-They are skipped automatically when OL is unreachable.
 """
 
 from __future__ import annotations
@@ -19,27 +19,17 @@ import pytest
 from fastapi.testclient import TestClient
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Helpers / markers
 # ---------------------------------------------------------------------------
 
 _OL_BASE_URL = os.environ.get("OL_BASE_URL", "http://localhost:8080")
-_CAROUSELS_URL = f"{_OL_BASE_URL}/search/carousels.json"
 
 
 def _ol_reachable() -> bool:
-    """Return True if the OL instance responds to a quick health probe."""
+    """Return True if the OL instance responds."""
     try:
         r = httpx.get(f"{_OL_BASE_URL}/", timeout=5.0)
         return r.status_code < 500
-    except httpx.RequestError:
-        return False
-
-
-def _carousels_endpoint_exists() -> bool:
-    """Return True if /search/carousels.json accepts POST (not 404/405)."""
-    try:
-        r = httpx.post(_CAROUSELS_URL, json={"queries": []}, timeout=5.0)
-        return r.status_code != 404
     except httpx.RequestError:
         return False
 
@@ -49,103 +39,39 @@ ol_available = pytest.mark.skipif(
     reason=f"OL not reachable at {_OL_BASE_URL} — start Docker first",
 )
 
-carousels_available = pytest.mark.skipif(
-    not _ol_reachable() or not _carousels_endpoint_exists(),
-    reason=f"POST /search/carousels.json not available at {_OL_BASE_URL} — needs PR #12987",
-)
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(scope="module")
 def opds_client():
-    """TestClient for the opds service, pointed at the local OL Docker."""
+    """TestClient for the OPDS service in-process, backed by live OL Docker."""
     os.environ["OL_BASE_URL"] = _OL_BASE_URL
     os.environ["ENVIRONMENT"] = "test"
     os.environ["CACHE_ENABLED"] = "false"
 
     from app.main import app
+
     with TestClient(app, raise_server_exceptions=True) as c:
         yield c
 
 
 # ---------------------------------------------------------------------------
-# /search/carousels.json — OL endpoint smoke tests
+# Home feed integration tests
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.e2e
-@carousels_available
-class TestCarouselsEndpointDirect:
-    """Smoke-test the OL /search/carousels.json endpoint directly."""
-
-    def test_single_query_returns_list(self):
-        r = httpx.post(
-            _CAROUSELS_URL,
-            json={"queries": [{"q": "subject:art", "limit": 3}]},
-            timeout=30.0,
-        )
-        assert r.status_code == 200
-        data = r.json()
-        assert isinstance(data, list)
-        assert len(data) == 1
-
-    def test_result_has_expected_search_fields(self):
-        r = httpx.post(
-            _CAROUSELS_URL,
-            json={"queries": [{"q": "subject:science", "limit": 5}]},
-            timeout=30.0,
-        )
-        assert r.status_code == 200
-        result = r.json()[0]
-        # Solr search response shape
-        assert "numFound" in result or "docs" in result or "works" in result, (
-            f"Unexpected response shape: {list(result.keys())}"
-        )
-
-    def test_multiple_queries_return_in_order(self):
-        queries = [
-            {"q": "subject:art", "limit": 2},
-            {"q": "subject:fantasy", "limit": 2},
-            {"q": "subject:science", "limit": 2},
-        ]
-        r = httpx.post(
-            _CAROUSELS_URL,
-            json={"queries": queries},
-            timeout=30.0,
-        )
-        assert r.status_code == 200
-        results = r.json()
-        assert len(results) == 3, f"Expected 3 results, got {len(results)}"
-
-    def test_max_query_cap_enforced(self):
-        """More than 20 queries should be rejected (422 Unprocessable Entity)."""
-        queries = [{"q": f"subject:{i}", "limit": 1} for i in range(21)]
-        r = httpx.post(
-            _CAROUSELS_URL,
-            json={"queries": queries},
-            timeout=10.0,
-        )
-        assert r.status_code == 422
-
-    def test_empty_query_list_rejected(self):
-        r = httpx.post(
-            _CAROUSELS_URL,
-            json={"queries": []},
-            timeout=10.0,
-        )
-        assert r.status_code == 422
-
-
-# ---------------------------------------------------------------------------
-# OPDS service home feed — end-to-end (opds service → OL Docker → Solr)
-# ---------------------------------------------------------------------------
-
-@pytest.mark.e2e
-@carousels_available
+@ol_available
 class TestOpdsHomeFeedE2E:
-    """Full stack: opds service in-process → real OL Docker → real Solr."""
+    """Full stack: OPDS service in-process → real OL Docker → real Solr.
+
+    Covers home feed structure, content, and query-parameter filtering.
+    Complements the external e2e tests in tests/test_e2e.py, which test the
+    same endpoints via httpx against a separately-started service instance.
+    """
 
     def test_home_returns_200(self, opds_client):
         r = opds_client.get("/")
@@ -153,68 +79,76 @@ class TestOpdsHomeFeedE2E:
 
     def test_home_returns_opds_content_type(self, opds_client):
         r = opds_client.get("/")
-        assert "opds" in r.headers.get("content-type", "").lower()
+        ct = r.headers.get("content-type", "").lower()
+        assert "opds" in ct, f"Expected OPDS content-type, got: {ct}"
 
-    def test_home_has_publications(self, opds_client):
+    def test_home_metadata_has_title(self, opds_client):
+        """Feed-level metadata must include a title."""
         r = opds_client.get("/")
-        assert r.status_code == 200
-        data = r.json()
-        # OPDS 2.0 catalog has a "publications" or "groups" list
-        groups = data.get("groups") or data.get("publications") or []
-        assert len(groups) > 0, (
-            "Home feed returned no groups — carousels endpoint may not be reachable"
-        )
+        meta = r.json().get("metadata") or {}
+        assert meta.get("title"), f"Feed metadata missing title: {meta}"
 
-    def test_home_groups_have_titles(self, opds_client):
+    def test_home_has_groups_with_titles(self, opds_client):
+        """Every group must carry a title in its metadata."""
         r = opds_client.get("/")
-        data = r.json()
-        groups = data.get("groups") or []
+        groups = r.json().get("groups") or []
+        assert len(groups) > 0, "Home feed returned no groups"
         for group in groups:
             meta = group.get("metadata") or {}
             assert meta.get("title"), f"Group missing title: {group}"
 
     def test_home_groups_have_publications(self, opds_client):
-        """At least one group should have publications (books)."""
+        """At least one publication must appear across all groups."""
         r = opds_client.get("/")
-        data = r.json()
-        groups = data.get("groups") or []
+        groups = r.json().get("groups") or []
         all_pubs = [p for g in groups for p in (g.get("publications") or [])]
-        assert len(all_pubs) > 0, (
-            "No publications found across all groups — Solr may have empty index"
-        )
+        assert len(all_pubs) > 0, "No publications found across all home-feed groups"
 
     def test_home_cover_urls_well_formed(self, opds_client):
-        """Cover image URLs should point to covers.openlibrary.org."""
+        """Cover image URLs must be https and point to a recognised OL domain."""
         r = opds_client.get("/")
-        data = r.json()
-        groups = data.get("groups") or []
-        cover_urls = []
-        for group in groups:
-            for pub in group.get("publications") or []:
-                for img in (pub.get("images") or []):
-                    href = img.get("href", "")
-                    if href:
-                        cover_urls.append(href)
-        # Only assert format if covers are present (empty Solr index is OK for e2e)
+        cover_urls = [
+            img.get("href", "")
+            for g in (r.json().get("groups") or [])
+            for pub in (g.get("publications") or [])
+            for img in (pub.get("images") or [])
+            if img.get("href")
+        ]
         for url in cover_urls[:10]:
             assert url.startswith("https://"), f"Cover URL not https: {url}"
             assert "covers.openlibrary.org" in url or "archive.org" in url, (
                 f"Unexpected cover URL domain: {url}"
             )
 
+    def test_home_navigation_links_present(self, opds_client):
+        """Feed must include at least a 'self' navigation link."""
+        r = opds_client.get("/")
+        links = r.json().get("links") or []
+        rels = {link.get("rel") for link in links}
+        assert "self" in rels, f"Missing 'self' link; rels found: {rels}"
+
     def test_home_ebooks_mode(self, opds_client):
-        """mode=ebooks should return 200 and a valid catalog."""
+        """mode=ebooks must return 200 with a valid catalog."""
         r = opds_client.get("/?mode=ebooks")
         assert r.status_code == 200
         data = r.json()
         assert "groups" in data or "publications" in data
 
-    def test_home_language_filter(self, opds_client):
-        """language=en filter should return 200."""
-        r = opds_client.get("/?language=en")
+    def test_home_open_access_mode(self, opds_client):
+        """mode=open_access must return 200."""
+        r = opds_client.get("/?mode=open_access")
         assert r.status_code == 200
 
+    def test_home_language_filter(self, opds_client):
+        """language=en must return 200 with non-empty groups."""
+        r = opds_client.get("/?language=en")
+        assert r.status_code == 200
+        groups = r.json().get("groups") or []
+        assert len(groups) > 0, "language=en filter returned no groups"
+
     def test_home_page2(self, opds_client):
-        """Second page of carousels should return 200."""
+        """Second page must return 200 with non-empty groups."""
         r = opds_client.get("/?page=2")
         assert r.status_code == 200
+        groups = r.json().get("groups") or []
+        assert len(groups) > 0, "Page 2 returned no groups"

--- a/tests/e2e/test_home_feed_e2e.py
+++ b/tests/e2e/test_home_feed_e2e.py
@@ -1,0 +1,220 @@
+"""
+End-to-end tests for the OPDS home feed.
+
+These tests require a live Open Library instance (with the /search/carousels.json
+endpoint from PR #12987) running at OL_BASE_URL (default: http://localhost:8080).
+
+Run with:
+    OL_BASE_URL=http://localhost:8080 pytest tests/e2e/ -m e2e -v
+
+They are skipped automatically when OL is unreachable.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_OL_BASE_URL = os.environ.get("OL_BASE_URL", "http://localhost:8080")
+_CAROUSELS_URL = f"{_OL_BASE_URL}/search/carousels.json"
+
+
+def _ol_reachable() -> bool:
+    """Return True if the OL instance responds to a quick health probe."""
+    try:
+        r = httpx.get(f"{_OL_BASE_URL}/", timeout=5.0)
+        return r.status_code < 500
+    except httpx.RequestError:
+        return False
+
+
+def _carousels_endpoint_exists() -> bool:
+    """Return True if /search/carousels.json accepts POST (not 404/405)."""
+    try:
+        r = httpx.post(_CAROUSELS_URL, json={"queries": []}, timeout=5.0)
+        return r.status_code != 404
+    except httpx.RequestError:
+        return False
+
+
+ol_available = pytest.mark.skipif(
+    not _ol_reachable(),
+    reason=f"OL not reachable at {_OL_BASE_URL} — start Docker first",
+)
+
+carousels_available = pytest.mark.skipif(
+    not _ol_reachable() or not _carousels_endpoint_exists(),
+    reason=f"POST /search/carousels.json not available at {_OL_BASE_URL} — needs PR #12987",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def opds_client():
+    """TestClient for the opds service, pointed at the local OL Docker."""
+    os.environ["OL_BASE_URL"] = _OL_BASE_URL
+    os.environ["ENVIRONMENT"] = "test"
+    os.environ["CACHE_ENABLED"] = "false"
+
+    from app.main import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# /search/carousels.json — OL endpoint smoke tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+@carousels_available
+class TestCarouselsEndpointDirect:
+    """Smoke-test the OL /search/carousels.json endpoint directly."""
+
+    def test_single_query_returns_list(self):
+        r = httpx.post(
+            _CAROUSELS_URL,
+            json={"queries": [{"q": "subject:art", "limit": 3}]},
+            timeout=30.0,
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+
+    def test_result_has_expected_search_fields(self):
+        r = httpx.post(
+            _CAROUSELS_URL,
+            json={"queries": [{"q": "subject:science", "limit": 5}]},
+            timeout=30.0,
+        )
+        assert r.status_code == 200
+        result = r.json()[0]
+        # Solr search response shape
+        assert "numFound" in result or "docs" in result or "works" in result, (
+            f"Unexpected response shape: {list(result.keys())}"
+        )
+
+    def test_multiple_queries_return_in_order(self):
+        queries = [
+            {"q": "subject:art", "limit": 2},
+            {"q": "subject:fantasy", "limit": 2},
+            {"q": "subject:science", "limit": 2},
+        ]
+        r = httpx.post(
+            _CAROUSELS_URL,
+            json={"queries": queries},
+            timeout=30.0,
+        )
+        assert r.status_code == 200
+        results = r.json()
+        assert len(results) == 3, f"Expected 3 results, got {len(results)}"
+
+    def test_max_query_cap_enforced(self):
+        """More than 20 queries should be rejected (422 Unprocessable Entity)."""
+        queries = [{"q": f"subject:{i}", "limit": 1} for i in range(21)]
+        r = httpx.post(
+            _CAROUSELS_URL,
+            json={"queries": queries},
+            timeout=10.0,
+        )
+        assert r.status_code == 422
+
+    def test_empty_query_list_rejected(self):
+        r = httpx.post(
+            _CAROUSELS_URL,
+            json={"queries": []},
+            timeout=10.0,
+        )
+        assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# OPDS service home feed — end-to-end (opds service → OL Docker → Solr)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+@carousels_available
+class TestOpdsHomeFeedE2E:
+    """Full stack: opds service in-process → real OL Docker → real Solr."""
+
+    def test_home_returns_200(self, opds_client):
+        r = opds_client.get("/")
+        assert r.status_code == 200
+
+    def test_home_returns_opds_content_type(self, opds_client):
+        r = opds_client.get("/")
+        assert "opds" in r.headers.get("content-type", "").lower()
+
+    def test_home_has_publications(self, opds_client):
+        r = opds_client.get("/")
+        assert r.status_code == 200
+        data = r.json()
+        # OPDS 2.0 catalog has a "publications" or "groups" list
+        groups = data.get("groups") or data.get("publications") or []
+        assert len(groups) > 0, (
+            "Home feed returned no groups — carousels endpoint may not be reachable"
+        )
+
+    def test_home_groups_have_titles(self, opds_client):
+        r = opds_client.get("/")
+        data = r.json()
+        groups = data.get("groups") or []
+        for group in groups:
+            meta = group.get("metadata") or {}
+            assert meta.get("title"), f"Group missing title: {group}"
+
+    def test_home_groups_have_publications(self, opds_client):
+        """At least one group should have publications (books)."""
+        r = opds_client.get("/")
+        data = r.json()
+        groups = data.get("groups") or []
+        all_pubs = [p for g in groups for p in (g.get("publications") or [])]
+        assert len(all_pubs) > 0, (
+            "No publications found across all groups — Solr may have empty index"
+        )
+
+    def test_home_cover_urls_well_formed(self, opds_client):
+        """Cover image URLs should point to covers.openlibrary.org."""
+        r = opds_client.get("/")
+        data = r.json()
+        groups = data.get("groups") or []
+        cover_urls = []
+        for group in groups:
+            for pub in group.get("publications") or []:
+                for img in (pub.get("images") or []):
+                    href = img.get("href", "")
+                    if href:
+                        cover_urls.append(href)
+        # Only assert format if covers are present (empty Solr index is OK for e2e)
+        for url in cover_urls[:10]:
+            assert url.startswith("https://"), f"Cover URL not https: {url}"
+            assert "covers.openlibrary.org" in url or "archive.org" in url, (
+                f"Unexpected cover URL domain: {url}"
+            )
+
+    def test_home_ebooks_mode(self, opds_client):
+        """mode=ebooks should return 200 and a valid catalog."""
+        r = opds_client.get("/?mode=ebooks")
+        assert r.status_code == 200
+        data = r.json()
+        assert "groups" in data or "publications" in data
+
+    def test_home_language_filter(self, opds_client):
+        """language=en filter should return 200."""
+        r = opds_client.get("/?language=en")
+        assert r.status_code == 200
+
+    def test_home_page2(self, opds_client):
+        """Second page of carousels should return 200."""
+        r = opds_client.get("/?page=2")
+        assert r.status_code == 200


### PR DESCRIPTION
## Summary

End-to-end tests for the OPDS home feed using FastAPI's `TestClient`
(in-process), backed by a real OL Docker instance.

**Original approach (removed):** Tests depended on `POST /search/carousels.json`
— an OL batch endpoint from PR #12987 that was never merged. All tests were
gated on `carousels_available` and silently skipped in every environment.

**New approach:** Tests cover the OPDS service's actual current behaviour:

| Test | What it verifies |
|------|-----------------|
| `test_home_returns_200` | Home feed responds |
| `test_home_returns_opds_content_type` | Response has OPDS content-type header |
| `test_home_metadata_has_title` | Feed-level metadata includes a title |
| `test_home_has_groups_with_titles` | Every group has a title |
| `test_home_groups_have_publications` | At least one publication across groups |
| `test_home_cover_urls_well_formed` | Cover URLs are https + OL domain |
| `test_home_navigation_links_present` | Feed includes a `self` link |
| `test_home_ebooks_mode` | `?mode=ebooks` returns 200 + valid catalog |
| `test_home_open_access_mode` | `?mode=open_access` returns 200 |
| `test_home_language_filter` | `?language=en` returns non-empty groups |
| `test_home_page2` | `?page=2` returns non-empty groups |

Tests auto-skip in CI when OL is not reachable at `OL_BASE_URL`.

## Relation to PR #41

PR #41 adds `tests/test_e2e.py` (external httpx against a running OPDS service).
This PR uses `TestClient` (in-process) — a complementary approach that validates
the service code path without needing the OPDS service pre-started.

## Testing

```
# Unit tests unaffected
python3 -m pytest tests/ --ignore=tests/e2e -q
# 155 passed

# Collection (CI without OL Docker — all 11 tests skip gracefully)
python3 -m pytest tests/e2e/ --collect-only -q
# 11 tests collected

# Full e2e run (requires OL Docker at localhost:8080)
OL_BASE_URL=http://localhost:8080 pytest tests/e2e/ -m e2e -v
```