### PR TITLE
ci: run e2e home feed tests against openlibrary.org on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,31 @@ jobs:
       - name: Run tests
         run: pytest tests/ -v --tb=short
 
+  test-e2e-prod:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install git+https://github.com/ArchiveLabs/pyopds2.git
+          pip install -r requirements.txt
+          pip install pytest httpx
+
+      - name: Run e2e tests against openlibrary.org
+        env:
+          OL_BASE_URL: https://openlibrary.org
+          ENVIRONMENT: test
+          CACHE_ENABLED: "false"
+        run: pytest tests/e2e/ -m e2e -v --tb=short
+
   docker-build:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary

Adds a `test-e2e-prod` CI job that runs `tests/e2e/` against production `openlibrary.org` on every PR.

The `tests/e2e/` suite (merged in #40) uses FastAPI's `TestClient` in-process — it starts the OPDS service code from the PR branch and points it at `OL_BASE_URL`. With `OL_BASE_URL=https://openlibrary.org`, each PR now gets genuine validation: the code under review handles real OL responses correctly.

This is what option 1 couldn't do for PR #40 itself (it was testing main, not the PR code) — but for future PRs that change route logic, cache handling, or feed construction, this job will catch regressions against the real OL API shape.

## What runs

11 tests covering:
- Home feed returns 200 + OPDS content-type
- Feed and group metadata include titles
- Groups contain publications
- Cover URLs are https + OL domain
- Navigation links include `self`
- `mode=ebooks` / `mode=open_access` filtering
- `language=en` filtering
- `page=2` pagination

## Resilience

`ol_available` probes `https://openlibrary.org/` at collection time. If OL is unreachable, all 11 tests skip and the job passes — a prod outage doesn't block merges.

`CACHE_ENABLED=false` ensures the in-process service makes live requests rather than hitting a Memcached server that doesn't exist in CI.