### PR TITLE
Fix/remove duplicate cors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,11 @@ install:
 
 # Start the service locally against real openlibrary.org.
 # Cache is disabled so every request exercises the full fetch path.
+# CORS is enabled because there's no fronting nginx locally — browser clients
+# (e.g. reader.archive.org via the Cloudflare tunnel) need the headers.
 # Use port 8090 to avoid conflicting with OL Docker on 8080.
 serve:
-	CACHE_ENABLED=false OL_BASE_URL=https://openlibrary.org \
+	CACHE_ENABLED=false CORS_ENABLED=true OL_BASE_URL=https://openlibrary.org \
 	  uvicorn app.main:app --host 127.0.0.1 --port 8090 --reload
 
 # Offline unit tests — no live service required

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -30,6 +30,13 @@ except ValueError:
     raise ValueError(f"MEMCACHE_PORT must be an integer, got: {_memcache_port_raw!r}") from None
 CACHE_ENABLED: bool = os.environ.get("CACHE_ENABLED", "true").lower() == "true"
 
+# App-level CORS. Off by default: in production the fronting nginx already adds
+# CORS headers, so enabling this here would emit a duplicate
+# ``Access-Control-Allow-Origin`` and break browser clients. Enable it for local
+# development (e.g. the Cloudflare-tunnel-to-reader.archive.org flow) where no
+# nginx sits in front. See docs/testing-opds-locally.md.
+CORS_ENABLED: bool = os.environ.get("CORS_ENABLED", "false").lower() == "true"
+
 SENTRY_DSN: str | None = os.environ.get(
     "SENTRY_DSN",
     "https://8d8cab445edc9b4e452ba06d0be46dcb@sentry.archive.org/73",
@@ -71,4 +78,5 @@ __all__ = [
     "MEMCACHE_HOST",
     "MEMCACHE_PORT",
     "CACHE_ENABLED",
+    "CORS_ENABLED",
 ]

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,7 @@ from app.exceptions import AuthorNotFound, EditionNotFound, UpstreamError
 from app.logger import get_logger
 from app.routes.opds import router as opds_router
 from app.sentry import init_sentry
-from app.config import ENVIRONMENT
+from app.config import CORS_ENABLED, ENVIRONMENT
 
 logger = get_logger(__name__)
 
@@ -67,6 +67,21 @@ app = FastAPI(
     redoc_url=None,
     openapi_url=None,
 )
+
+# OPDS is a public read-only catalog API. In production the fronting nginx
+# already supplies CORS headers; enabling this here would duplicate
+# ``Access-Control-Allow-Origin`` and break browser clients. Gate it behind
+# CORS_ENABLED so local dev without nginx (e.g. the Cloudflare tunnel to
+# reader.archive.org) can still be consumed by browsers.
+if CORS_ENABLED:
+    from fastapi.middleware.cors import CORSMiddleware
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["GET"],
+        allow_headers=["*"],
+    )
 
 
 class EndpointFilter(logging.Filter):

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,6 @@ import os
 import time
 
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from app.cache import get_cache, LANG_OPTIONS_KEY, TTL_LANG_OPTIONS_SECONDS
@@ -67,15 +66,6 @@ app = FastAPI(
     docs_url=None,
     redoc_url=None,
     openapi_url=None,
-)
-
-# OPDS is a public read-only catalog API — allow any origin so browser-based
-# OPDS clients (reader.archive.org, web extensions, etc.) can consume it.
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["GET"],
-    allow_headers=["*"],
 )
 
 

--- a/docs/testing-opds-locally.md
+++ b/docs/testing-opds-locally.md
@@ -57,11 +57,14 @@ python3 -c "import pyopds2_openlibrary; print(pyopds2_openlibrary.__file__)"
 cd ~/Projects/opds.openlibrary.org
 
 CACHE_ENABLED=false \
+CORS_ENABLED=true \
 OL_BASE_URL=https://openlibrary.org \
 uvicorn app.main:app --host 127.0.0.1 --port 8090
 ```
 
 `CACHE_ENABLED=false` ensures every request hits OL directly — no stale cache responses during testing.
+
+`CORS_ENABLED=true` adds CORS headers so browser clients (e.g. reader.archive.org) can consume the feed. It is off by default because production's fronting nginx already supplies CORS — enabling it there would emit a duplicate `Access-Control-Allow-Origin` header and break browsers. (`make serve` sets both for you.)
 
 Verify the service is up:
 
@@ -190,5 +193,5 @@ pkill -f "uvicorn app.main"
 | Port 8090 already in use | `pkill -f "uvicorn app.main"` or change port |
 | Tunnel URL not resolving yet | Wait 10–15 s after the URL appears before testing |
 | `docker-compose.yml` fails if worktree is not named `opds.openlibrary.org` | Use `uvicorn` directly (this guide); the compose file hard-codes that path |
-| reader.archive.org CORS error | Ensure `CORSMiddleware` is in `app/main.py` (added in PR #41) |
+| reader.archive.org CORS error | Start the service with `CORS_ENABLED=true` (or use `make serve`) so the app emits CORS headers locally |
 | Home feed returns 0 groups | OL is rate-limiting or unreachable; check `/health` and OL status |


### PR DESCRIPTION
The unconditional CORSMiddleware (reverted in the previous commit)
duplicated the CORS headers that production's fronting nginx already
emits, producing two `Access-Control-Allow-Origin: *` headers whenever a
browser sent an `Origin` request header — which reader.archive.org and
other browser OPDS clients reject as "multiple values '*, *'".

Reintroduce the middleware behind a CORS_ENABLED flag (default false) so
production stays single-sourced through nginx, while local development
without a fronting proxy (the Cloudflare-tunnel-to-reader.archive.org
flow) can opt in. `make serve` and the local-testing docs set it.
